### PR TITLE
Day & Tower Input Parameters.

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -66,7 +66,7 @@ func main() {
 	agentHP := 100
 	agentsPerFloor := 1 //more than one not currently supported
 	numberOfFloors := simulation.Sum(numOfAgents) / agentsPerFloor
-	ticksPerFloor := 1
+	ticksPerFloor := 10
 
 	ticksPerDay := numberOfFloors * ticksPerFloor
 	simDays := 3

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -60,16 +60,18 @@ func main() {
 	log.SetOutput(f)
 	log.SetFormatter(&log.JSONFormatter{})
 
-	ticksPerDay := 24 * 60
-	simDays := 3
-	reshuffleDays := 1
-	dayInfo := day.NewDayInfo(ticksPerDay, simDays, reshuffleDays)
-
 	// can have frontend parameters come go straight into simEnv
 	foodOnPlatform := 100.0
 	numOfAgents := []int{2, 2, 2}
 	agentHP := 100
 	agentsPerFloor := 1 //more than one not currently supported
+	numberOfFloors := simulation.Sum(numOfAgents) / agentsPerFloor
+	ticksPerFloor := 1
+
+	ticksPerDay := numberOfFloors * ticksPerFloor
+	simDays := 3
+	reshuffleDays := 1
+	dayInfo := day.NewDayInfo(ticksPerFloor, ticksPerDay, simDays, reshuffleDays)
 
 	// TODO: agentParameters - struct
 

--- a/pkg/infra/tower.go
+++ b/pkg/infra/tower.go
@@ -50,14 +50,13 @@ func (t *Tower) Tick() {
 
 	//useful parameters
 	numOfFloors := t.agentCount / t.agentsPerFloor
-	platformMovePeriod := t.dayInfo.TicksPerDay / numOfFloors // can add min/max
 
 	// Shuffle the agents
 	if t.dayInfo.CurrTick%t.dayInfo.TicksPerReshuffle == 0 {
 		t.reshuffle(numOfFloors)
 	}
 	// Move the platform
-	if t.dayInfo.CurrTick%platformMovePeriod == 0 {
+	if t.dayInfo.CurrTick%t.dayInfo.TicksPerFloor == 0 {
 		t.currPlatFloor++
 	}
 	// Decrease agent HP and reset tower at end of day

--- a/pkg/simulation/simulation.go
+++ b/pkg/simulation/simulation.go
@@ -48,7 +48,7 @@ func (sE *SimEnv) Simulate() {
 	sE.Log("Simulation Initializing")
 	a := abm.New()
 
-	totalAgents := sum(sE.AgentCount)
+	totalAgents := Sum(sE.AgentCount)
 	t := infra.NewTower(sE.FoodOnPlatform, totalAgents, 1, sE.dayInfo)
 	a.SetWorld(t)
 
@@ -78,7 +78,8 @@ func (sE *SimEnv) simulationLoop(a *abm.ABM, t *infra.Tower) {
 	}
 }
 
-func sum(inputList []int) int {
+// TODO: move this to a general functions file.
+func Sum(inputList []int) int {
 	totalAgents := 0
 	for _, value := range inputList {
 		totalAgents += value

--- a/pkg/utils/globalTypes/day/day.go
+++ b/pkg/utils/globalTypes/day/day.go
@@ -1,6 +1,7 @@
 package day
 
 type DayInfo struct {
+	TicksPerFloor     int
 	TicksPerDay       int
 	SimulationDays    int
 	DaysPerReshuffle  int
@@ -9,8 +10,9 @@ type DayInfo struct {
 	CurrTick          int
 }
 
-func NewDayInfo(TicksPerDay, SimulationDays, DaysPerReshuffle int) *DayInfo {
+func NewDayInfo(TicksPerFloor, TicksPerDay, SimulationDays, DaysPerReshuffle int) *DayInfo {
 	return &DayInfo{
+		TicksPerFloor:     TicksPerFloor,
 		TicksPerDay:       TicksPerDay,
 		SimulationDays:    SimulationDays,
 		DaysPerReshuffle:  DaysPerReshuffle,


### PR DESCRIPTION
Ticks per day now dependent on other variables.

# Summary

This PR is aiming to solve the issue #13 . Day and tower parameters as set from discussion in meeting. 

## Additional Information

From meeting: input params: composition of agents (and therefore total number of agents), number of agents per floor (this will need to be a factor of the total number of agents), time spent per floor. (Courtesy of @jzzheng22 )

## Test Plan

Tested by observing logs of reshuffling etc while changing `ticksPerFloor` in main.go - changes day length as expected.