### PR TITLE
Add ID to message

### DIFF
--- a/pkg/messages/baseMessage.go
+++ b/pkg/messages/baseMessage.go
@@ -1,5 +1,9 @@
 package messages
 
+import (
+	"github.com/google/uuid"
+)
+
 //Define message types to enable basic protocols, voting systems ...etc
 type Message interface {
 	MessageType() string
@@ -8,11 +12,13 @@ type Message interface {
 type baseMessage struct {
 	SenderFloor  int
 	responseType Message
+	messageID    string
 }
 
 func NewBaseMessage(SenderFloor int) *baseMessage {
 	msg := &baseMessage{
 		SenderFloor: SenderFloor,
+		messageID:   uuid.New().String(),
 	}
 	return msg
 }
@@ -26,4 +32,7 @@ func (msg baseMessage) MessageType() string {
 
 func (msg *baseMessage) ResponseType() string {
 	return msg.responseType.MessageType()
+}
+func (msg *baseMessage) MessageID() string {
+	return msg.messageID
 }


### PR DESCRIPTION
# Summary

Each message now has a unique ID. If an agent sends out multiple messages, they can now e.g. remember in their state which messages are still pending or which messages have been "resolved". 