### PR TITLE
Parametrise backend using a config json file

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1,15 +1,15 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/SOMAS2021/SOMAS2021/pkg/config"
 	"github.com/SOMAS2021/SOMAS2021/pkg/simulation"
-	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/day"
-	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/food"
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/health"
 	log "github.com/sirupsen/logrus"
 )
@@ -36,34 +36,21 @@ func main() {
 	log.SetOutput(f)
 	log.SetFormatter(&log.JSONFormatter{})
 
-	// can have frontend parameters come go straight into simEnv
-	foodOnPlatform := food.FoodType(100)
-	numOfAgents := []int{2, 2, 2, 2, 2, 2, 2} //agent1, agent2, team3, team4EvoAgent, team 5, team6, randomAgent
-	agentHP := 100
-	agentsPerFloor := 1 //more than one not currently supported
-	numberOfFloors := simulation.Sum(numOfAgents) / agentsPerFloor
-	ticksPerFloor := 10
+	//processing the command-line flags
+	//currently only one used is -configpath, but we are likely to need more in the near future.
+	// if not set, it uses default of "config.json"
+	configPathPtr := flag.String("configpath", "config.json", "path for parameter configuration json file")
 
-	ticksPerDay := numberOfFloors * ticksPerFloor
-	simDays := 8
-	reshuffleDays := 1
-	dayInfo := day.NewDayInfo(ticksPerFloor, ticksPerDay, simDays, reshuffleDays)
+	parameters, err := config.LoadParamFromJson(*configPathPtr)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
-	// define health parameters
-	maxHP := 100
-	weakLevel := 10
-	width := 45.0
-	tau := 10.0
-	hpReqCToW := 2
-	hpCritical := 5
-	maxDayCritical := 3
-	HPLossBase := 10
-	HPLossSlope := 0.25
-
-	healthInfo := health.NewHealthInfo(maxHP, weakLevel, width, tau, hpReqCToW, hpCritical, maxDayCritical, HPLossBase, HPLossSlope)
+	healthInfo := health.NewHealthInfo(parameters.MaxHP, parameters.WeakLevel, parameters.Width, parameters.Tau, parameters.HpReqCToW, parameters.HpCritical, parameters.MaxDayCritical, parameters.HPLossBase, parameters.HPLossSlope)
 
 	// TODO: agentParameters - struct
 
-	simEnv := simulation.NewSimEnv(foodOnPlatform, numOfAgents, agentHP, agentsPerFloor, dayInfo, healthInfo)
+	simEnv := simulation.NewSimEnv(parameters.FoodOnPlatform, parameters.NumOfAgents, parameters.AgentHP, parameters.AgentsPerFloor, parameters.DayInfo, healthInfo)
 	simEnv.Simulate()
 }

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -47,10 +47,11 @@ func main() {
 		return
 	}
 
-	healthInfo := health.NewHealthInfo(parameters.MaxHP, parameters.WeakLevel, parameters.Width, parameters.Tau, parameters.HpReqCToW, parameters.HpCritical, parameters.MaxDayCritical, parameters.HPLossBase, parameters.HPLossSlope)
+	healthInfo := health.NewHealthInfo(&parameters)
 
 	// TODO: agentParameters - struct
 
-	simEnv := simulation.NewSimEnv(parameters.FoodOnPlatform, parameters.NumOfAgents, parameters.AgentHP, parameters.AgentsPerFloor, parameters.DayInfo, healthInfo)
+	simEnv := simulation.NewSimEnv(&parameters, healthInfo)
+
 	simEnv.Simulate()
 }

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -41,6 +41,8 @@ func main() {
 	// if not set, it uses default of "config.json"
 	configPathPtr := flag.String("configpath", "config.json", "path for parameter configuration json file")
 
+	flag.Parse()
+
 	parameters, err := config.LoadParamFromJson(*configPathPtr)
 	if err != nil {
 		fmt.Println(err)

--- a/config.json
+++ b/config.json
@@ -1,0 +1,18 @@
+{
+    "FoodOnPlatform": 100,
+    "NumOfAgents": [2,2,2,2,2,2,2],
+    "AgentHP": 100,
+    "AgentsPerFloor": 1,
+    "TicksPerFloor": 10,
+    "SimDays": 8,
+    "ReshuffleDays": 1,
+    "maxHP": 100,
+    "weakLevel": 10,
+    "width": 45,
+    "tau": 10,
+    "hpReqCToW": 2,
+    "hpCritical": 5,
+    "maxDayCritical": 3,
+    "HPLossBase": 10,
+    "HPLossSlope": 0.25
+}

--- a/config.json
+++ b/config.json
@@ -1,6 +1,12 @@
 {
     "FoodOnPlatform": 100,
-    "NumOfAgents": [2,2,2,2,2,2,2],
+    "Team1Agents": 2,
+    "Team2Agents": 2,
+    "Team3Agents": 2,
+    "Team4Agents": 2,
+    "Team5Agents": 2,
+    "Team6Agents": 2,
+    "RandomAgents": 2,
     "AgentHP": 100,
     "AgentsPerFloor": 1,
     "TicksPerFloor": 10,

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -13,7 +13,13 @@ import (
 
 type ConfigParameters struct {
 	FoodOnPlatform food.FoodType `json:"FoodOnPlatform"`
-	NumOfAgents    []int         `json:"NumOfAgents"`
+	Team1Agents    int           `json:"Team1Agents"`
+	Team2Agents    int           `json:"Team2Agents"`
+	Team3Agents    int           `json:"Team3Agents"`
+	Team4Agents    int           `json:"Team4Agents"`
+	Team5Agents    int           `json:"Team5Agents"`
+	Team6Agents    int           `json:"Team6Agents"`
+	RandomAgents   int           `json:"RandomAgents"`
 	AgentHP        int           `json:"AgentHP"`
 	AgentsPerFloor int           `json:"AgentsPerFloor"`
 	TicksPerFloor  int           `json:"TicksPerFloor"`
@@ -28,6 +34,7 @@ type ConfigParameters struct {
 	MaxDayCritical int           `json:"maxDayCritical"`
 	HPLossBase     int           `json:"HPLossBase"`
 	HPLossSlope    float64       `json:"HPLossSlope"`
+	NumOfAgents    []int
 	NumberOfFloors int
 	TicksPerDay    int
 	DayInfo        *day.DayInfo
@@ -56,6 +63,9 @@ func LoadParamFromJson(path string) (ConfigParameters, error) {
 	tempParameters.NumberOfFloors = utilfunctions.Sum(tempParameters.NumOfAgents) / tempParameters.AgentsPerFloor
 	tempParameters.TicksPerDay = tempParameters.NumberOfFloors * tempParameters.TicksPerFloor
 	tempParameters.DayInfo = day.NewDayInfo(tempParameters.TicksPerFloor, tempParameters.TicksPerDay, tempParameters.SimDays, tempParameters.ReshuffleDays)
+
+	//appending the sizes of the agents to the array
+	tempParameters.NumOfAgents = append(tempParameters.NumOfAgents, tempParameters.Team1Agents, tempParameters.Team2Agents, tempParameters.Team3Agents, tempParameters.Team4Agents, tempParameters.Team5Agents, tempParameters.Team6Agents, tempParameters.RandomAgents)
 
 	return tempParameters, nil
 }

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -59,13 +59,13 @@ func LoadParamFromJson(path string) (ConfigParameters, error) {
 	if err != nil {
 		return tempParameters, err
 	}
+	//appending the sizes of the agents to the array
+	tempParameters.NumOfAgents = append(tempParameters.NumOfAgents, tempParameters.Team1Agents, tempParameters.Team2Agents, tempParameters.Team3Agents, tempParameters.Team4Agents, tempParameters.Team5Agents, tempParameters.Team6Agents, tempParameters.RandomAgents)
+
 	//do the calculations for parameters that depend on other parameters
 	tempParameters.NumberOfFloors = utilfunctions.Sum(tempParameters.NumOfAgents) / tempParameters.AgentsPerFloor
 	tempParameters.TicksPerDay = tempParameters.NumberOfFloors * tempParameters.TicksPerFloor
 	tempParameters.DayInfo = day.NewDayInfo(tempParameters.TicksPerFloor, tempParameters.TicksPerDay, tempParameters.SimDays, tempParameters.ReshuffleDays)
-
-	//appending the sizes of the agents to the array
-	tempParameters.NumOfAgents = append(tempParameters.NumOfAgents, tempParameters.Team1Agents, tempParameters.Team2Agents, tempParameters.Team3Agents, tempParameters.Team4Agents, tempParameters.Team5Agents, tempParameters.Team6Agents, tempParameters.RandomAgents)
 
 	return tempParameters, nil
 }

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -6,9 +6,9 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/SOMAS2021/SOMAS2021/pkg/simulation" //for the sum function. That function should probably be moved somewhere else, like utils
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/day"
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/food"
+	"github.com/SOMAS2021/SOMAS2021/pkg/utils/utilfunctions"
 )
 
 type ConfigParameters struct {
@@ -53,7 +53,7 @@ func LoadParamFromJson(path string) (ConfigParameters, error) {
 		return tempParameters, err
 	}
 	//do the calculations for parameters that depend on other parameters
-	tempParameters.NumberOfFloors = simulation.Sum(tempParameters.NumOfAgents) / tempParameters.AgentsPerFloor
+	tempParameters.NumberOfFloors = utilfunctions.Sum(tempParameters.NumOfAgents) / tempParameters.AgentsPerFloor
 	tempParameters.TicksPerDay = tempParameters.NumberOfFloors * tempParameters.TicksPerFloor
 	tempParameters.DayInfo = day.NewDayInfo(tempParameters.TicksPerFloor, tempParameters.TicksPerDay, tempParameters.SimDays, tempParameters.ReshuffleDays)
 

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -48,8 +48,10 @@ func LoadParamFromJson(path string) (ConfigParameters, error) {
 	//parse it and put values in tempParameters
 	byteValue, _ := ioutil.ReadAll(jsonFile)
 
-	json.Unmarshal(byteValue, &tempParameters)
-
+	err = json.Unmarshal(byteValue, &tempParameters)
+	if err != nil {
+		return tempParameters, err
+	}
 	//do the calculations for parameters that depend on other parameters
 	tempParameters.NumberOfFloors = simulation.Sum(tempParameters.NumOfAgents) / tempParameters.AgentsPerFloor
 	tempParameters.TicksPerDay = tempParameters.NumberOfFloors * tempParameters.TicksPerFloor

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+
+	"github.com/SOMAS2021/SOMAS2021/pkg/simulation" //for the sum function. That function should probably be moved somewhere else, like utils
+	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/day"
+	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/food"
+)
+
+type ConfigParameters struct {
+	FoodOnPlatform food.FoodType `json:"FoodOnPlatform"`
+	NumOfAgents    []int         `json:"NumOfAgents"`
+	AgentHP        int           `json:"AgentHP"`
+	AgentsPerFloor int           `json:"AgentsPerFloor"`
+	TicksPerFloor  int           `json:"TicksPerFloor"`
+	SimDays        int           `json:"SimDays"`
+	ReshuffleDays  int           `json:"ReshuffleDays"`
+	MaxHP          int           `json:"maxHP"`
+	WeakLevel      int           `json:"weakLevel"`
+	Width          float64       `json:"width"`
+	Tau            float64       `json:"tau"`
+	HpReqCToW      int           `json:"hpReqCToW"`
+	HpCritical     int           `json:"hpCritical"`
+	MaxDayCritical int           `json:"maxDayCritical"`
+	HPLossBase     int           `json:"HPLossBase"`
+	HPLossSlope    float64       `json:"HPLossSlope"`
+	NumberOfFloors int
+	TicksPerDay    int
+	DayInfo        *day.DayInfo
+}
+
+func LoadParamFromJson(path string) (ConfigParameters, error) {
+
+	var tempParameters ConfigParameters
+
+	// Open our jsonFile
+	jsonFile, err := os.Open(path)
+	if err != nil {
+		return tempParameters, errors.New("Unable to open " + path)
+	}
+	// defer the closing of our jsonFile so that we can parse it later on
+	defer jsonFile.Close()
+
+	//parse it and put values in tempParameters
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+
+	json.Unmarshal(byteValue, &tempParameters)
+
+	//do the calculations for parameters that depend on other parameters
+	tempParameters.NumberOfFloors = simulation.Sum(tempParameters.NumOfAgents) / tempParameters.AgentsPerFloor
+	tempParameters.TicksPerDay = tempParameters.NumberOfFloors * tempParameters.TicksPerFloor
+	tempParameters.DayInfo = day.NewDayInfo(tempParameters.TicksPerFloor, tempParameters.TicksPerDay, tempParameters.SimDays, tempParameters.ReshuffleDays)
+
+	return tempParameters, nil
+}

--- a/pkg/infra/baseagent.go
+++ b/pkg/infra/baseagent.go
@@ -134,6 +134,9 @@ func (a *Base) setHasEaten(newStatus bool) {
 }
 
 func (a *Base) TakeFood(amountOfFood food.FoodType) food.FoodType {
+	if amountOfFood == 0 {
+		return 0
+	}
 	if a.floor == a.tower.currPlatFloor && !a.hasEaten && amountOfFood > 0 {
 		foodTaken := food.FoodType(math.Min(float64(a.tower.currPlatFood), float64(amountOfFood)))
 		a.updateHP(foodTaken)
@@ -142,7 +145,7 @@ func (a *Base) TakeFood(amountOfFood food.FoodType) food.FoodType {
 		a.Log("An agent has taken food", Fields{"floor": a.floor, "amount": foodTaken})
 		return foodTaken
 	}
-	return 0
+	return -1
 }
 
 func (a *Base) ReceiveMessage() messages.Message {

--- a/pkg/infra/tower.go
+++ b/pkg/infra/tower.go
@@ -85,7 +85,7 @@ func (t *Tower) Reshuffle() {
 	// iterate through the uuid strings of each agent
 	for _, agent := range t.Agents {
 		newFloor := rand.Intn(numOfFloors)
-		for remainingVacancies[newFloor] == 0 {
+		for remainingVacancies[newFloor] == 0 || newFloor == agent.BaseAgent().floor {
 			newFloor = rand.Intn(numOfFloors)
 		}
 		agent.BaseAgent().setFloor(newFloor + 1)

--- a/pkg/simulation/simulation.go
+++ b/pkg/simulation/simulation.go
@@ -1,11 +1,13 @@
 package simulation
 
 import (
+	"github.com/SOMAS2021/SOMAS2021/pkg/config"
 	"github.com/SOMAS2021/SOMAS2021/pkg/infra"
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/day"
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/food"
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/health"
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/world"
+	"github.com/SOMAS2021/SOMAS2021/pkg/utils/utilfunctions"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -22,14 +24,14 @@ type SimEnv struct {
 	world          world.World
 }
 
-func NewSimEnv(foodOnPlat food.FoodType, agentCount []int, agentHP, agentsPerFloor int, dayInfo *day.DayInfo, healthInfo *health.HealthInfo) *SimEnv {
+func NewSimEnv(parameters *config.ConfigParameters, healthInfo *health.HealthInfo) *SimEnv {
 	return &SimEnv{
-		FoodOnPlatform: foodOnPlat,
-		AgentCount:     agentCount,
-		AgentHP:        agentHP,
-		dayInfo:        dayInfo,
+		FoodOnPlatform: parameters.FoodOnPlatform,
+		AgentCount:     parameters.NumOfAgents,
+		AgentHP:        parameters.AgentHP,
+		dayInfo:        parameters.DayInfo,
 		healthInfo:     healthInfo,
-		AgentsPerFloor: agentsPerFloor,
+		AgentsPerFloor: parameters.AgentsPerFloor,
 		logger:         *log.WithFields(log.Fields{"reporter": "simulation"}),
 	}
 }
@@ -37,7 +39,7 @@ func NewSimEnv(foodOnPlat food.FoodType, agentCount []int, agentHP, agentsPerFlo
 func (sE *SimEnv) Simulate() {
 	sE.Log("Simulation Initializing")
 
-	totalAgents := Sum(sE.AgentCount)
+	totalAgents := utilfunctions.Sum(sE.AgentCount)
 	t := infra.NewTower(sE.FoodOnPlatform, totalAgents, sE.AgentsPerFloor, sE.dayInfo, sE.healthInfo)
 	sE.SetWorld(t)
 
@@ -46,15 +48,6 @@ func (sE *SimEnv) Simulate() {
 	sE.Log("Simulation Started")
 	sE.simulationLoop(t)
 	sE.Log("Simulation Ended")
-}
-
-// TODO: move to a general list of functions
-func Sum(inputList []int) int {
-	totalAgents := 0
-	for _, value := range inputList {
-		totalAgents += value
-	}
-	return totalAgents
 }
 
 func (s *SimEnv) Log(message string, fields ...Fields) {

--- a/pkg/utils/globalTypes/health/health.go
+++ b/pkg/utils/globalTypes/health/health.go
@@ -1,5 +1,9 @@
 package health
 
+import (
+	"github.com/SOMAS2021/SOMAS2021/pkg/config"
+)
+
 type HealthInfo struct {
 	// Maximum HP
 	MaxHP int
@@ -20,16 +24,18 @@ type HealthInfo struct {
 	HPLossSlope float64
 }
 
-func NewHealthInfo(MaxHP, WeakLevel int, Width, Tau float64, HPReqCToW, HPCritical, MaxDayCritical, HPLossBase int, HPLossSlope float64) *HealthInfo {
+func NewHealthInfo(parameters *config.ConfigParameters) *HealthInfo {
 	return &HealthInfo{
-		MaxHP:          MaxHP,
-		WeakLevel:      WeakLevel,
-		Width:          Width,
-		Tau:            Tau,
-		HPReqCToW:      HPReqCToW,
-		HPCritical:     HPCritical,
-		MaxDayCritical: MaxDayCritical,
-		HPLossBase:     HPLossBase,
-		HPLossSlope:    HPLossSlope,
+		MaxHP:          parameters.MaxHP,
+		WeakLevel:      parameters.WeakLevel,
+		Width:          parameters.Width,
+		Tau:            parameters.Tau,
+		HPReqCToW:      parameters.HpReqCToW,
+		HPCritical:     parameters.HpCritical,
+		MaxDayCritical: parameters.MaxDayCritical,
+		HPLossBase:     parameters.HPLossBase,
+		HPLossSlope:    parameters.HPLossSlope,
 	}
 }
+
+*/

--- a/pkg/utils/globalTypes/health/health.go
+++ b/pkg/utils/globalTypes/health/health.go
@@ -37,5 +37,3 @@ func NewHealthInfo(parameters *config.ConfigParameters) *HealthInfo {
 		HPLossSlope:    parameters.HPLossSlope,
 	}
 }
-
-*/

--- a/pkg/utils/usefulFunctions/usefulfunctions.go
+++ b/pkg/utils/usefulFunctions/usefulfunctions.go
@@ -1,0 +1,9 @@
+package usefulfunctions
+
+func Sum(inputList []int) int {
+	totalAgents := 0
+	for _, value := range inputList {
+		totalAgents += value
+	}
+	return totalAgents
+}

--- a/pkg/utils/utilfunctions/utilfunctions.go
+++ b/pkg/utils/utilfunctions/utilfunctions.go
@@ -1,4 +1,4 @@
-package usefulfunctions
+package utilfunctions
 
 func Sum(inputList []int) int {
 	totalAgents := 0
@@ -6,4 +6,5 @@ func Sum(inputList []int) int {
 		totalAgents += value
 	}
 	return totalAgents
+
 }


### PR DESCRIPTION
# Summary

This solves issue #82

Main now loads the runtime parameters from a json file, and puts them inside a `ConfigParameters` struct that contains pretty much all parameters needed. 

New `config` package created for the `ConfigParameters` struct and the `LoadParamFromJson` function

The `LoadParamFromJson` function  is used to parse the json and convert it into a struct and is also hopefully very similar to what will be required for the frontend communication to parse the json ( issue #81 )

## Additional Information

Also added functionality for command-line flags to allow the used to choose the location of the config file, however if none is provided, then it will use the config.json file which already contains the default values of previous commit. 

