### PR TITLE
Rewrite Reshuffle() to remove infinite loop

### DIFF
--- a/pkg/infra/tower.go
+++ b/pkg/infra/tower.go
@@ -74,22 +74,21 @@ func (t *Tower) AddAgent(agent Agent) {
 	t.Agents[agent.BaseAgent().id] = agent
 }
 
+// This function shuffles the agents by generating a random permutation of agentCount intgers,
+// and maps the integers into floors by dividing each integer by the number of agents per floor.
+// This function does not guarantee that an agent will be moved to a different floor.
 func (t *Tower) Reshuffle() {
-	numOfFloors := t.agentCount / t.agentsPerFloor
-	remainingVacancies := make([]int, numOfFloors)
-	t.Log("Reshuffling alive agents...", Fields{"agents_count": len(t.Agents)})
-	for i := 0; i < numOfFloors; i++ { // adding a max to each floor
-		remainingVacancies[i] = t.agentsPerFloor
-	}
-	// allocating agents to floors randomly
-	// iterate through the uuid strings of each agent
+	t.Log("Shuffling agents")
+	newFloors := rand.Perm(t.agentCount)
+	i := 0
 	for _, agent := range t.Agents {
-		newFloor := rand.Intn(numOfFloors)
-		for remainingVacancies[newFloor] == 0 || newFloor == agent.BaseAgent().floor {
-			newFloor = rand.Intn(numOfFloors)
-		}
-		agent.BaseAgent().setFloor(newFloor + 1)
-		remainingVacancies[newFloor]--
+		agent := agent.BaseAgent()
+		newFloor := newFloors[i]/t.agentsPerFloor + 1
+
+		t.Log("Floor change", Fields{"agent_id": agent.ID(), "old_floor": agent.Floor(), "new_floor": newFloor})
+
+		agent.setFloor(newFloor)
+		i++
 	}
 }
 


### PR DESCRIPTION
Closes #116.

Note that this function now allows agents to be shuffled onto their previous floors.

