### PR TITLE
Logging dead agents during simulation

### DIFF
--- a/pkg/infra/tower.go
+++ b/pkg/infra/tower.go
@@ -23,6 +23,7 @@ type Tower struct {
 	dayInfo        *day.DayInfo
 	healthInfo     *health.HealthInfo
 	mx             sync.RWMutex
+	deadAgents     map[int]int
 }
 
 func (t *Tower) Log(message string, fields ...Fields) {
@@ -48,6 +49,7 @@ func NewTower(maxPlatFood food.FoodType, agentCount,
 		logger:         *log.WithFields(log.Fields{"reporter": "tower"}),
 		dayInfo:        dayInfo,
 		healthInfo:     healthInfo,
+		deadAgents:     make(map[int]int),
 	}
 }
 
@@ -143,4 +145,12 @@ func (t *Tower) TotalAgents() int {
 	t.mx.RLock()
 	defer t.mx.RUnlock()
 	return len(t.Agents)
+}
+
+func (t *Tower) UpdateDeadAgents(agentType int) {
+	t.deadAgents[agentType]++
+}
+
+func (t *Tower) DeadAgents() map[int]int {
+	return t.deadAgents
 }

--- a/pkg/simulation/simAgent.go
+++ b/pkg/simulation/simAgent.go
@@ -48,7 +48,9 @@ func (sE *SimEnv) replaceAgents(t *infra.Tower) {
 		agent := agent.BaseAgent()
 		if !agent.IsAlive() {
 			delete(t.Agents, uuid)
+			sE.Log("An Agent has died", infra.Fields{"Agent Type": agent.AgentType()})
 			sE.createNewAgent(t, agent.AgentType(), agent.Floor())
+			t.UpdateDeadAgents(agent.AgentType())
 		}
 	}
 }

--- a/pkg/simulation/simAgent.go
+++ b/pkg/simulation/simAgent.go
@@ -48,9 +48,10 @@ func (sE *SimEnv) replaceAgents(t *infra.Tower) {
 		agent := agent.BaseAgent()
 		if !agent.IsAlive() {
 			delete(t.Agents, uuid)
-			sE.Log("An Agent has died", infra.Fields{"Agent Type": agent.AgentType()})
-			sE.createNewAgent(t, agent.AgentType(), agent.Floor())
+			sE.Log("An Agent has died", infra.Fields{"agent_type": agent.AgentType()})
 			t.UpdateDeadAgents(agent.AgentType())
+			sE.createNewAgent(t, agent.AgentType(), agent.Floor())
+
 		}
 	}
 }

--- a/pkg/simulation/simulation.go
+++ b/pkg/simulation/simulation.go
@@ -48,6 +48,7 @@ func (sE *SimEnv) Simulate() {
 	sE.Log("Simulation Started")
 	sE.simulationLoop(t)
 	sE.Log("Simulation Ended")
+	sE.Log("Summary of dead agents", infra.Fields{"Agent Type and amount that died": t.DeadAgents()})
 }
 
 func (s *SimEnv) Log(message string, fields ...Fields) {

--- a/pkg/simulation/simulation.go
+++ b/pkg/simulation/simulation.go
@@ -48,7 +48,7 @@ func (sE *SimEnv) Simulate() {
 	sE.Log("Simulation Started")
 	sE.simulationLoop(t)
 	sE.Log("Simulation Ended")
-	sE.Log("Summary of dead agents", infra.Fields{"Agent Type and amount that died": t.DeadAgents()})
+	sE.Log("Summary of dead agents", infra.Fields{"Agent Type and number that died": t.DeadAgents()})
 }
 
 func (s *SimEnv) Log(message string, fields ...Fields) {


### PR DESCRIPTION
-Added deadAgents mapping parameter to tower struct
-Added UpdateDeadAgents function
-Added DeadAgents function
-Added logs for when agent dies
-Added log for summary of dead agents at end of simulation

# Summary

Added parameter to tower to track dead agents during the simulations.
Added logs for when agent has died and a summary at the end of the simulation.
Added functions to tower.

<!--
*Pssst...you... yes you! Did you run `make lint` and perhaps `make format`? If not, go away, run those commands, and then come back (if you are using VS Code... then you shouldn't need to do `make lint`*
-->

<!--
Please provide a summary of the change. What does this PR do? What does it solve?
-->

## Additional Information

Not sure if this is the best way to store and track this information. Please tell me if you have any other suggestions.

Currently works with agentType as int but I understand this is likely to change, so the changes here will have to be modified slightly when this happens.

<!--
Auxiliary information and additional context for the change goes here.
-->

## Test Plan

Increased the number of simulation days for testing and checked logs over multiple simulations.

<!--
Add information on how you tested your changes.
-->