### PR TITLE
Add code to handle agent updates at end of day

### DIFF
--- a/pkg/infra/baseagent.go
+++ b/pkg/infra/baseagent.go
@@ -2,6 +2,7 @@ package infra
 
 import (
 	"errors"
+	"fmt"
 	"math"
 
 	"github.com/SOMAS2021/SOMAS2021/pkg/messages"
@@ -39,6 +40,7 @@ type Base struct {
 	logger         log.Entry
 	hasEaten       bool
 	daysAtCritical int
+	age            int
 }
 
 func NewBaseAgent(world world.World, agentType int, agentHP int, agentFloor int, id string) (*Base, error) {
@@ -61,6 +63,7 @@ func NewBaseAgent(world world.World, agentType int, agentHP int, agentFloor int,
 		logger:         *logger,
 		hasEaten:       false,
 		daysAtCritical: 0,
+		age:            0,
 	}, nil
 }
 
@@ -82,6 +85,23 @@ func (a *Base) Run() {
 func (a *Base) HP() int {
 	return utilFunctions.MinInt(a.hp, 100)
 }
+
+func (a *Base) Age() int {
+	return a.age
+}
+
+func (a *Base) increaseAge() {
+	a.age++
+}
+
+// func (a *Base) updateTreaties() {
+// 	for _, treaty in a.activeTreaties {
+// 		treaty.duration--
+// 		if treaty.duration == 0 {
+// 			//remove
+// 		}
+// 	}
+// }
 
 // only show the food on the platform if the platform is on the
 // same floor as the agent or directly below
@@ -130,7 +150,31 @@ func (a *Base) updateHP(foodTaken food.FoodType) {
 	} else {
 		a.hp = int(math.Min(float64(a.tower.healthInfo.HPCritical+a.tower.healthInfo.HPReqCToW), float64(a.hp)+hpChange))
 	}
+}
 
+func (a *Base) hpDecay(healthInfo *health.HealthInfo) {
+	newHP := 0
+	if a.hp >= healthInfo.WeakLevel {
+		newHP = utilFunctions.MinInt(healthInfo.MaxHP, a.hp-(healthInfo.HPLossBase+int(float64(a.hp-healthInfo.WeakLevel)*healthInfo.HPLossSlope)))
+	} else {
+		if a.hp >= healthInfo.HPCritical+healthInfo.HPReqCToW {
+			newHP = healthInfo.WeakLevel
+			a.daysAtCritical = 0
+		} else {
+			newHP = healthInfo.HPCritical
+			a.daysAtCritical++
+		}
+	}
+	if newHP < healthInfo.WeakLevel {
+		newHP = healthInfo.HPCritical
+	}
+	a.setHasEaten(false)
+	if a.daysAtCritical >= healthInfo.MaxDayCritical {
+		a.Log("Killing agent")
+		newHP = 0
+	}
+	a.Log("Setting hp to " + fmt.Sprint(newHP))
+	a.setHP(newHP)
 }
 
 func (a *Base) HasEaten() bool {

--- a/pkg/infra/baseagent.go
+++ b/pkg/infra/baseagent.go
@@ -94,15 +94,6 @@ func (a *Base) increaseAge() {
 	a.age++
 }
 
-// func (a *Base) updateTreaties() {
-// 	for _, treaty in a.activeTreaties {
-// 		treaty.duration--
-// 		if treaty.duration == 0 {
-// 			//remove
-// 		}
-// 	}
-// }
-
 // only show the food on the platform if the platform is on the
 // same floor as the agent or directly below
 func (a *Base) CurrPlatFood() food.FoodType {

--- a/pkg/infra/tower.go
+++ b/pkg/infra/tower.go
@@ -66,7 +66,6 @@ func (t *Tower) Tick() {
 	// Decrease agent HP and reset tower at end of day
 	if t.dayInfo.CurrTick%t.dayInfo.TicksPerDay == 0 {
 		t.endOfDay()
-		// t.hpDecay() // decreases HP and kills if < 0
 		t.ResetTower()
 		t.Log("-----------------END----OF----DAY-----------------", Fields{})
 	}
@@ -99,7 +98,6 @@ func (t *Tower) endOfDay() {
 		agent := agent.BaseAgent()
 		agent.hpDecay(t.healthInfo)
 		agent.increaseAge()
-		// agent.updateTreaties()
 	}
 }
 

--- a/pkg/infra/tower.go
+++ b/pkg/infra/tower.go
@@ -1,7 +1,6 @@
 package infra
 
 import (
-	"math"
 	"math/rand"
 	"sync"
 
@@ -66,7 +65,8 @@ func (t *Tower) Tick() {
 	}
 	// Decrease agent HP and reset tower at end of day
 	if t.dayInfo.CurrTick%t.dayInfo.TicksPerDay == 0 {
-		t.hpDecay() // decreases HP and kills if < 0
+		t.endOfDay()
+		// t.hpDecay() // decreases HP and kills if < 0
 		t.ResetTower()
 		t.Log("-----------------END----OF----DAY-----------------", Fields{})
 	}
@@ -94,33 +94,12 @@ func (t *Tower) Reshuffle() {
 	}
 }
 
-func (t *Tower) hpDecay() {
+func (t *Tower) endOfDay() {
 	for _, agent := range t.Agents {
 		agent := agent.BaseAgent()
-		newHP := 0
-
-		if agent.hp >= t.healthInfo.WeakLevel {
-			newHP = int(math.Min(float64(t.healthInfo.MaxHP), float64(agent.hp)-(float64(t.healthInfo.HPLossBase)+float64(agent.hp-t.healthInfo.WeakLevel)*t.healthInfo.HPLossSlope)))
-		} else {
-			if agent.hp >= t.healthInfo.HPCritical+t.healthInfo.HPReqCToW {
-				newHP = t.healthInfo.WeakLevel
-				agent.daysAtCritical = 0
-			} else {
-				newHP = t.healthInfo.HPCritical
-				agent.daysAtCritical++
-			}
-		}
-
-		if newHP < t.healthInfo.WeakLevel {
-			newHP = t.healthInfo.HPCritical
-		}
-
-		agent.setHasEaten(false)
-		if agent.daysAtCritical >= t.healthInfo.MaxDayCritical {
-			t.Log("Killing agent", Fields{"agent": agent.id})
-			newHP = 0
-		}
-		agent.setHP(newHP)
+		agent.hpDecay(t.healthInfo)
+		agent.increaseAge()
+		// agent.updateTreaties()
 	}
 }
 


### PR DESCRIPTION
# Summary
Following discussion of how we will be handling treaties, I'm changing the code that is run at the end of each day:

- At the end of a day, the function `t.endOfDay()` is called.
- This function then calls:
    - `agent.hpDecay()`
    - `agent.increaseAge()`
    - `agent.updateTreaties()` - this is currently commented out, however once we implement the other treaty code, can be uncommented.
-  There is also an initial implementation, commented out, for `updateTreaties()`.

I've also moved `hpDecay()` from tower to agent, and mildly refactored it to use `utilFunctions.MinInt()` so we don't have to cast the numbers to floats.

I've also added an age field to the base agent - this will be needed when we have treaties.