### PR TITLE
Implemented HTTP Request and Response for Frontend communication, and option to define log file name using config

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,6 +6,7 @@
     "Team4Agents": 2,
     "Team5Agents": 2,
     "Team6Agents": 2,
+    "Team7Agent1": 2,
     "RandomAgents": 2,
     "AgentHP": 100,
     "AgentsPerFloor": 1,

--- a/pkg/agents/team7/agent1/agent.go
+++ b/pkg/agents/team7/agent1/agent.go
@@ -1,0 +1,167 @@
+package team7agent1
+
+import (
+	"github.com/SOMAS2021/SOMAS2021/pkg/infra"
+	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/food"
+	"math/rand"
+)
+
+/*
+
+Openness 	high-> doesn't get effected by new floors, looks forward to new day
+			low-> does get effected by new floors
+
+Currently implemented by changing attributes on reshuffles
+
+Conscientiousness high-> plans ahead, attentive and takes into account messgages
+			low-> no planning, fails to complete assigned tasks
+
+Not implemented yet
+
+
+Extraversion high-> very likely to communicate, will share a lot of information
+			low-> does not like to communicate
+
+Not implemented yet
+
+Agreeableness high-> caring so more likely to go hungry for the betterment of others, trustworthy
+			low-> greedy, manipulative
+
+
+Implemented by intialising attributes, not considering health state yet
+
+
+Neuroticism high-> dramatic mood swings, struggles to recover after weak state
+			low-> stable, relaxed and resilient
+
+
+
+
+*/
+
+type team7Personalities struct {
+	openness int
+
+	conscientiousness int
+
+	extraversion int
+
+	agreeableness int
+
+	neuroticism int
+}
+
+type CustomAgent7 struct {
+	*infra.Base
+	personality  team7Personalities
+	greediness   int
+	kindness     int
+	daysHungry   int
+	seenPlatform bool
+	foodEaten    food.FoodType
+	prevHP       int
+	prevFloors   []int
+}
+
+func New(baseAgent *infra.Base) (infra.Agent, error) {
+	openness := rand.Intn(100)
+	conscientiousness := rand.Intn(100)
+	extraversion := rand.Intn(100)
+	agreeableness := rand.Intn(100)
+	neuroticism := rand.Intn(100)
+	return &CustomAgent7{
+		Base: baseAgent,
+		personality: team7Personalities{
+			openness:          openness,
+			conscientiousness: conscientiousness,
+			extraversion:      extraversion,
+			agreeableness:     agreeableness,
+			neuroticism:       neuroticism,
+		},
+		greediness:   100 - agreeableness,
+		kindness:     agreeableness,
+		daysHungry:   0,
+		seenPlatform: false,
+		foodEaten:    0,
+		prevHP:       100,
+		prevFloors:   []int{},
+	}, nil
+}
+
+func (a *CustomAgent7) Run() {
+
+	a.Log("Team7Agent1 reporting status:", infra.Fields{"floor": a.Floor(), "hp": a.HP(), "greed": a.greediness, "kind": a.kindness, "aggr": a.personality.agreeableness})
+
+	//Check if floor has changed
+	if len(a.prevFloors) == 0 || a.prevFloors[len(a.prevFloors)-1] != a.Floor() {
+
+		currentFloor := a.Floor()
+
+		if len(a.prevFloors) != 0 {
+			prevFloor := a.prevFloors[len(a.prevFloors)-1]
+
+			if currentFloor < prevFloor {
+				//only negatively impacted if openness is low
+				if a.personality.openness <= 50 {
+					a.greediness += (currentFloor - prevFloor)
+				}
+
+			} else {
+				//if we have moved up our kindness increases
+				a.kindness += (prevFloor - currentFloor)
+			}
+
+		}
+		a.prevFloors = append(a.prevFloors, currentFloor)
+	}
+
+	//receive Message
+
+	//eat
+
+	//choses random number between -5 and 5
+	if a.CurrPlatFood() != -1 {
+
+		r1 := rand.Intn(11) - 5
+		r2 := rand.Intn(11) - 5
+
+		a.kindness += (a.personality.neuroticism * r1) / 50
+		a.greediness += (a.personality.neuroticism * r2) / 50
+
+		if a.kindness < 0 {
+			a.kindness = 0
+		} else if a.kindness > 100 {
+			a.kindness = 100
+		}
+
+		if a.greediness < 0 {
+			a.greediness = 0
+		} else if a.greediness > 100 {
+			a.greediness = 100
+		}
+
+		foodtotake := food.FoodType(100 - a.kindness + a.greediness)
+
+		//has the agent seen the platform
+		if a.CurrPlatFood() != -1 && !a.seenPlatform {
+			a.foodEaten = a.TakeFood(foodtotake)
+			if a.foodEaten > 0 {
+				a.daysHungry = 0
+			} else {
+				a.daysHungry++
+			}
+			a.Log("Team 7 has seen the platform:", infra.Fields{"foodEaten": a.foodEaten, "health": a.HP(), "daysHungry": a.daysHungry})
+			a.seenPlatform = true
+		}
+
+		if (a.CurrPlatFood() == -1 && a.seenPlatform) || a.CurrPlatFood() == 100 {
+			//Get ready for new day
+			a.seenPlatform = false
+			a.prevHP = a.HP()
+		}
+
+	}
+
+	//send Message
+
+}

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -19,6 +19,7 @@ type ConfigParameters struct {
 	Team4Agents    int           `json:"Team4Agents"`
 	Team5Agents    int           `json:"Team5Agents"`
 	Team6Agents    int           `json:"Team6Agents"`
+	Team7Agent1    int           `json:"Team7Agent1"`
 	RandomAgents   int           `json:"RandomAgents"`
 	AgentHP        int           `json:"AgentHP"`
 	AgentsPerFloor int           `json:"AgentsPerFloor"`
@@ -60,7 +61,7 @@ func LoadParamFromJson(path string) (ConfigParameters, error) {
 		return tempParameters, err
 	}
 	//appending the sizes of the agents to the array
-	tempParameters.NumOfAgents = append(tempParameters.NumOfAgents, tempParameters.Team1Agents, tempParameters.Team2Agents, tempParameters.Team3Agents, tempParameters.Team4Agents, tempParameters.Team5Agents, tempParameters.Team6Agents, tempParameters.RandomAgents)
+	tempParameters.NumOfAgents = append(tempParameters.NumOfAgents, tempParameters.Team1Agents, tempParameters.Team2Agents, tempParameters.Team3Agents, tempParameters.Team4Agents, tempParameters.Team5Agents, tempParameters.Team6Agents, tempParameters.Team7Agent1, tempParameters.RandomAgents)
 
 	//do the calculations for parameters that depend on other parameters
 	tempParameters.NumberOfFloors = utilFunctions.Sum(tempParameters.NumOfAgents) / tempParameters.AgentsPerFloor

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"net/http"
 	"os"
 
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/day"
@@ -35,10 +36,16 @@ type ConfigParameters struct {
 	MaxDayCritical int           `json:"maxDayCritical"`
 	HPLossBase     int           `json:"HPLossBase"`
 	HPLossSlope    float64       `json:"HPLossSlope"`
+	LogFileName    string        `json:"LogFileName"`
 	NumOfAgents    []int
 	NumberOfFloors int
 	TicksPerDay    int
 	DayInfo        *day.DayInfo
+}
+
+type Response struct { // used for HTTP response
+	Success     bool   `json:"Success"`
+	LogFileName string `json:"LogFileName"`
 }
 
 func LoadParamFromJson(path string) (ConfigParameters, error) {
@@ -60,13 +67,35 @@ func LoadParamFromJson(path string) (ConfigParameters, error) {
 	if err != nil {
 		return tempParameters, err
 	}
-	//appending the sizes of the agents to the array
-	tempParameters.NumOfAgents = append(tempParameters.NumOfAgents, tempParameters.Team1Agents, tempParameters.Team2Agents, tempParameters.Team3Agents, tempParameters.Team4Agents, tempParameters.Team5Agents, tempParameters.Team6Agents, tempParameters.Team7Agent1, tempParameters.RandomAgents)
 
-	//do the calculations for parameters that depend on other parameters
-	tempParameters.NumberOfFloors = utilFunctions.Sum(tempParameters.NumOfAgents) / tempParameters.AgentsPerFloor
-	tempParameters.TicksPerDay = tempParameters.NumberOfFloors * tempParameters.TicksPerFloor
-	tempParameters.DayInfo = day.NewDayInfo(tempParameters.TicksPerFloor, tempParameters.TicksPerDay, tempParameters.SimDays, tempParameters.ReshuffleDays)
+	CalculateDependantParameters(&tempParameters)
 
 	return tempParameters, nil
+}
+
+//parses the body of HTTP request (assumes json format, same as the config files), and returns the config struct
+func LoadParamFromHTTPRequest(r *http.Request) (ConfigParameters, error) {
+
+	var tempParameters ConfigParameters
+
+	err := json.NewDecoder(r.Body).Decode(&tempParameters)
+	if err != nil {
+		return tempParameters, err
+	}
+
+	CalculateDependantParameters(&tempParameters)
+
+	return tempParameters, nil
+}
+
+//Some parameters depend directly on other parameters. This function calculates them and updates the original struct
+func CalculateDependantParameters(parameters *ConfigParameters) {
+
+	//appending the sizes of the agents to the array
+	parameters.NumOfAgents = append(parameters.NumOfAgents, parameters.Team1Agents, parameters.Team2Agents, parameters.Team3Agents, parameters.Team4Agents, parameters.Team5Agents, parameters.Team6Agents, parameters.Team7Agent1, parameters.RandomAgents)
+
+	//do the calculations for parameters that depend on other parameters
+	parameters.NumberOfFloors = utilFunctions.Sum(parameters.NumOfAgents) / parameters.AgentsPerFloor
+	parameters.TicksPerDay = parameters.NumberOfFloors * parameters.TicksPerFloor
+	parameters.DayInfo = day.NewDayInfo(parameters.TicksPerFloor, parameters.TicksPerDay, parameters.SimDays, parameters.ReshuffleDays)
 }

--- a/pkg/simulation/simAgent.go
+++ b/pkg/simulation/simAgent.go
@@ -8,6 +8,7 @@ import (
 	team4EvoAgent "github.com/SOMAS2021/SOMAS2021/pkg/agents/team4/agent1"
 	team5 "github.com/SOMAS2021/SOMAS2021/pkg/agents/team5/agent1"
 	"github.com/SOMAS2021/SOMAS2021/pkg/agents/team6"
+	team7agent1 "github.com/SOMAS2021/SOMAS2021/pkg/agents/team7/agent1"
 	"github.com/SOMAS2021/SOMAS2021/pkg/infra"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
@@ -28,7 +29,7 @@ func (sE *SimEnv) generateInitialAgents(t *infra.Tower) {
 
 func (sE *SimEnv) createNewAgent(tower *infra.Tower, i, floor int) {
 	sE.Log("Creating new agent")
-	abs := []AgentNewFunc{agent1.New, agent2.New, team3.New, team4EvoAgent.New, team5.New, team6.New, randomAgent.New}
+	abs := []AgentNewFunc{agent1.New, agent2.New, team3.New, team4EvoAgent.New, team5.New, team6.New, team7agent1.New, randomAgent.New}
 	// NOTE(woonmoon): Leaving the line below commented just in case any teams want to run the 2-agent
 	// 				   configuration to see how the message-passing works.
 	// abs := []AgentNewFunc{agent1.New, agent2.New}


### PR DESCRIPTION
Closes Issue #128 and #141 

When the backend runs in serve mode, whenever it gets a HTTP request, it loads the parameters from the request body, and runs the simulation. It also generates a response and sends it back. The response contains the log file name, and a success boolean. Currently the success is hard coded, but soon I will make it depend on a timeout in a different PR (issue #142)

It also now allows setting a log file name through the config using parameter `LogFileName` either through the config.json, or through the HTTP request. This will be useful for the dashboard to make it easier to differentiate between different logs.

Screenshots of requests and responses:

<details>
  <summary>HTTP Request, no log name change</summary>

  ![image](https://user-images.githubusercontent.com/56606852/147692159-e9e00d9b-1b74-432c-9f81-c0b127b4b67a.png)

</details>

<details>
  <summary>HTTP Request, with name change</summary>

![image](https://user-images.githubusercontent.com/56606852/147692225-a9f57de0-2855-476f-8b98-b29caac4de44.png)

</details>

Double slashes is because this is how json represents special characters (As far as i can tell). When reading it, it automatically has just one slash.
