### PR TITLE
Remove unnecessary mutex

### DIFF
--- a/pkg/infra/tower.go
+++ b/pkg/infra/tower.go
@@ -2,7 +2,6 @@ package infra
 
 import (
 	"math/rand"
-	"sync"
 
 	"github.com/SOMAS2021/SOMAS2021/pkg/messages"
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/day"
@@ -21,7 +20,6 @@ type Tower struct {
 	logger         log.Entry
 	dayInfo        *day.DayInfo
 	healthInfo     *health.HealthInfo
-	mx             sync.RWMutex
 	deadAgents     map[int]int
 }
 
@@ -121,8 +119,6 @@ func (t *Tower) ResetTower() {
 }
 
 func (t *Tower) TotalAgents() int {
-	t.mx.RLock()
-	defer t.mx.RUnlock()
 	return len(t.Agents)
 }
 


### PR DESCRIPTION
# Summary
Don't need this mutex - we never call that function at all, but also we never modify the list of agents inside a goroutine.
<!--
*Pssst...you... yes you! Did you run `make lint` and perhaps `make format`? If not, go away, run those commands, and then come back (if you are using VS Code... then you shouldn't need to do `make lint`*
-->

<!--
Please provide a summary of the change. What does this PR do? What does it solve?
-->

## Additional Information

<!--
Auxiliary information and additional context for the change goes here.
-->

## Test Plan

<!--
Add information on how you tested your changes.
-->