### PR TITLE
Fix reply function: missing senderID in interface

### DIFF
--- a/pkg/messages/baseMessage.go
+++ b/pkg/messages/baseMessage.go
@@ -44,7 +44,7 @@ type Message interface {
 
 type AskMessage interface {
 	Message
-	Reply(senderFloor int, food int) StateMessage
+	Reply(senderID uuid.UUID, senderFloor int, food int) StateMessage
 }
 
 type StateMessage interface {
@@ -55,13 +55,13 @@ type StateMessage interface {
 type RequestMessage interface {
 	Message
 	Request() int
-	Reply(senderFloor int, response bool) ResponseMessage
+	Reply(senderID uuid.UUID, senderFloor int, response bool) ResponseMessage
 }
 
 type ResponseMessage interface {
 	Message
 	Response() bool
-	RequestId() uuid.UUID
+	RequestID() uuid.UUID
 }
 
 type BaseMessage struct {

--- a/pkg/messages/responseMessage.go
+++ b/pkg/messages/responseMessage.go
@@ -8,11 +8,11 @@ type BoolResponseMessage struct {
 	requestId uuid.UUID
 }
 
-func NewResponseMessage(senderID uuid.UUID, senderFloor int, response bool, requestId uuid.UUID) *BoolResponseMessage {
+func NewResponseMessage(senderID uuid.UUID, senderFloor int, response bool, requestID uuid.UUID) *BoolResponseMessage {
 	msg := &BoolResponseMessage{
 		NewBaseMessage(senderID, senderFloor, Response),
 		response,
-		requestId,
+		requestID,
 	}
 	return msg
 }
@@ -21,7 +21,7 @@ func (msg *BoolResponseMessage) Response() bool {
 	return msg.response
 }
 
-func (msg *BoolResponseMessage) RequestId() uuid.UUID {
+func (msg *BoolResponseMessage) RequestID() uuid.UUID {
 	return msg.requestId
 }
 


### PR DESCRIPTION
# Summary
Bugfix: forgot to put `senderID` in reply interface.

Also changing `RequestId` to `RequestID` for consistency
<!--
*Pssst...you... yes you! Did you run `make lint` and perhaps `make format`? If not, go away, run those commands, and then come back (if you are using VS Code... then you shouldn't need to do `make lint`*
-->

<!--
MAKE SURE YOU HAVE WRITTEN UNIT TESTS FOR YOUR CODE!!!
-->

<!--
Please provide a summary of the change. What does this PR do? What does it solve?
-->

## Additional Information

<!--
Auxiliary information and additional context for the change goes here.
-->

## Test Plan

<!--
Add information on how you tested your changes.
-->