### PR TITLE
Move agent replacement to end of day instead of start of day

### DIFF
--- a/pkg/simulation/simIteration.go
+++ b/pkg/simulation/simIteration.go
@@ -23,9 +23,9 @@ func (sE *SimEnv) simulationLoop(t *infra.Tower) {
 	for sE.dayInfo.CurrTick <= sE.dayInfo.TotalTicks {
 		sE.Log("", Fields{"Current Simulation Tick": sE.dayInfo.CurrTick})
 		t.TowerStateLog(" start of tick")
-		sE.replaceAgents(t)
 		sE.AgentsRun(t)
 		sE.TowerTick()
+		sE.replaceAgents(t)
 		sE.dayInfo.CurrTick++
 	}
 }


### PR DESCRIPTION
# Summary
Bug where if an agent dies in the last tick their death isn't reported at the end in the death summary.

Example:
```
{"agent_id":"7bf7d0e2-8c96-4d1b-854e-4d7d0363ca5c","agent_type":5,"level":"info","msg":"Killing agent","reporter":"agent","time":"2021-12-30T15:17:07Z"}
{"agent_id":"7bf7d0e2-8c96-4d1b-854e-4d7d0363ca5c","agent_type":5,"level":"info","msg":"Setting hp to 0","reporter":"agent","time":"2021-12-30T15:17:07Z"}
{"agent_id":"abe8652e-3a7a-409d-9aa5-89e04893f050","agent_type":1,"level":"info","msg":"Setting hp to 44","reporter":"agent","time":"2021-12-30T15:17:07Z"}
{"agent_id":"0c156615-ad79-4cbf-9366-c6ae7830e5e8","agent_type":1,"level":"info","msg":"Setting hp to 29","reporter":"agent","time":"2021-12-30T15:17:07Z"}
{"agent_id":"6624452b-902f-42fa-9337-5e52f6f994ad","agent_type":3,"level":"info","msg":"Setting hp to 10","reporter":"agent","time":"2021-12-30T15:17:07Z"}
{"agent_id":"27f06ce6-6d93-4067-993e-dd06815d05f1","agent_type":7,"level":"info","msg":"Setting hp to 44","reporter":"agent","time":"2021-12-30T15:17:07Z"}
{"agent_id":"b6c771a1-e333-44d2-a081-0e4e067d63e2","agent_type":2,"level":"info","msg":"Setting hp to 15","reporter":"agent","time":"2021-12-30T15:17:07Z"}
{"agent_id":"4f9ee2f9-4127-4304-9acb-ac9dbfc834b9","agent_type":2,"level":"info","msg":"Setting hp to 10","reporter":"agent","time":"2021-12-30T15:17:07Z"}
{"level":"info","msg":"Tower Reset","reporter":"tower","time":"2021-12-30T15:17:07Z"}
{"level":"info","msg":"-----------------END----OF----DAY-----------------","reporter":"tower","time":"2021-12-30T15:17:07Z"}
{"level":"info","msg":"Simulation Ended","reporter":"simulation","time":"2021-12-30T15:17:07Z"}
{"Agent Type and number that died":{},"level":"info","msg":"Summary of dead agents","reporter":"simulation","time":"2021-12-30T15:17:07Z"}
```
<!--
*Pssst...you... yes you! Did you run `make lint` and perhaps `make format`? If not, go away, run those commands, and then come back (if you are using VS Code... then you shouldn't need to do `make lint`*
-->

<!--
MAKE SURE YOU HAVE WRITTEN UNIT TESTS FOR YOUR CODE!!!
-->

<!--
Please provide a summary of the change. What does this PR do? What does it solve?
-->

## Additional Information

<!--
Auxiliary information and additional context for the change goes here.
-->

## Test Plan

<!--
Add information on how you tested your changes.
-->