### PR TITLE
Implemented Food Per Agent Ratio

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,5 +22,6 @@
     "hpCritical": 5,
     "maxDayCritical": 3,
     "HPLossBase": 10,
-    "HPLossSlope": 0.25
+    "HPLossSlope": 0.25,
+    "LogMain": true
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,7 @@
 {
+    "UseFoodPerAgentRatio": false,
     "FoodOnPlatform": 100,
+    "FoodPerAgentRatio": 0,
     "Team1AgtOne": 2,
     "Team1AgtTwo": 2,
     "Team2Agents": 2,

--- a/main.go
+++ b/main.go
@@ -72,45 +72,60 @@ func main() {
 }
 
 // Returns the logfile name as it is needed in the HTTP response
-func runNewSimulation(parameters config.ConfigParameters) (logfileName string) {
+func runNewSimulation(parameters config.ConfigParameters) (logFolderName string) {
 	rand.Seed(time.Now().UnixNano())
-	f, err := setupLogFile(parameters.LogFileName)
+	f, logFolderName, err := setupLogFile(parameters.LogFileName, parameters.LogMain)
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	if f != nil {
+		defer f.Close()
+	}
 	healthInfo := health.NewHealthInfo(&parameters)
-
+	parameters.LogFileName = logFolderName
 	// TODO: agentParameters - struct
 	simEnv := simulation.NewSimEnv(&parameters, healthInfo)
 	simEnv.Simulate()
-	return f.Name()
+	return logFolderName
 }
 
-func setupLogFile(parameterLogFileName string) (fp *os.File, err error) {
+func setupLogFile(parameterLogFileName string, saveMainLog bool) (fp *os.File, folderName string, err error) {
+	// setup logs folder if never created
 	if _, err := os.Stat("logs"); os.IsNotExist(err) {
 		err := os.Mkdir("logs", 0755)
 		if err != nil {
 			fmt.Println("failed to create logs directory: ", err)
-			return nil, err
+			return nil, "", err
 		}
 	}
 
-	logfileName := ""
-	// Check if the log file name was set in config
+	// setup simulation run folder for logs
+	logFolderName := ""
+	// Check if the log folder name was set in config
 	if len(parameterLogFileName) != 0 {
-		logfileName = filepath.Join("logs", parameterLogFileName)
+		logFolderName = filepath.Join("logs", parameterLogFileName)
 	} else {
-		logfileName = filepath.Join("logs", time.Now().Format("2006-01-02-15-04-05")+".json")
+		logFolderName = filepath.Join("logs", time.Now().Format("2006-01-02-15-04-05"))
+	}
+	if _, err := os.Stat(logFolderName); os.IsNotExist(err) {
+		err := os.Mkdir(logFolderName, 0755)
+		if err != nil {
+			fmt.Println("failed to create custom folder directory: ", err)
+			return nil, "", err
+		}
 	}
 
-	f, err := os.OpenFile(logfileName, os.O_CREATE|os.O_RDWR, 0666)
-	if err != nil {
-		fmt.Println("error opening file: ", err)
-		return nil, err
+	// open main log file if asked
+	var f *os.File = nil
+	if saveMainLog {
+		logFileName := filepath.Join(logFolderName, "main.json")
+		f, err = os.OpenFile(logFileName, os.O_CREATE|os.O_RDWR, 0666)
+		if err != nil {
+			fmt.Println("error opening file: ", err)
+			return nil, logFolderName, err
+		}
+		log.SetOutput(f)
+		log.SetFormatter(&log.JSONFormatter{})
 	}
-
-	log.SetOutput(f)
-	log.SetFormatter(&log.JSONFormatter{})
-	return f, nil
+	return f, logFolderName, nil
 }

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -15,7 +15,7 @@ import (
 type ConfigParameters struct {
 	FoodOnPlatform food.FoodType `json:"FoodOnPlatform"`
 	Team1AgtOne    int           `json:"Team1AgtOne"`
-	Team1AgtTwo    int           `json:"Team2AgtTwo"`
+	Team1AgtTwo    int           `json:"Team1AgtTwo"`
 	Team2Agents    int           `json:"Team2Agents"`
 	Team3Agents    int           `json:"Team3Agents"`
 	Team4Agents    int           `json:"Team4Agents"`
@@ -38,6 +38,7 @@ type ConfigParameters struct {
 	HPLossBase     int           `json:"HPLossBase"`
 	HPLossSlope    float64       `json:"HPLossSlope"`
 	LogFileName    string        `json:"LogFileName"`
+	LogMain        bool          `json:"LogMain"`
 	NumOfAgents    []int
 	NumberOfFloors int
 	TicksPerDay    int

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -13,36 +13,38 @@ import (
 )
 
 type ConfigParameters struct {
-	FoodOnPlatform food.FoodType `json:"FoodOnPlatform"`
-	Team1AgtOne    int           `json:"Team1AgtOne"`
-	Team1AgtTwo    int           `json:"Team1AgtTwo"`
-	Team2Agents    int           `json:"Team2Agents"`
-	Team3Agents    int           `json:"Team3Agents"`
-	Team4Agents    int           `json:"Team4Agents"`
-	Team5Agents    int           `json:"Team5Agents"`
-	Team6Agents    int           `json:"Team6Agents"`
-	Team7Agent1    int           `json:"Team7Agent1"`
-	RandomAgents   int           `json:"RandomAgents"`
-	AgentHP        int           `json:"AgentHP"`
-	AgentsPerFloor int           `json:"AgentsPerFloor"`
-	TicksPerFloor  int           `json:"TicksPerFloor"`
-	SimDays        int           `json:"SimDays"`
-	ReshuffleDays  int           `json:"ReshuffleDays"`
-	MaxHP          int           `json:"maxHP"`
-	WeakLevel      int           `json:"weakLevel"`
-	Width          float64       `json:"width"`
-	Tau            float64       `json:"tau"`
-	HpReqCToW      int           `json:"hpReqCToW"`
-	HpCritical     int           `json:"hpCritical"`
-	MaxDayCritical int           `json:"maxDayCritical"`
-	HPLossBase     int           `json:"HPLossBase"`
-	HPLossSlope    float64       `json:"HPLossSlope"`
-	LogFileName    string        `json:"LogFileName"`
-	LogMain        bool          `json:"LogMain"`
-	NumOfAgents    []int
-	NumberOfFloors int
-	TicksPerDay    int
-	DayInfo        *day.DayInfo
+	FoodOnPlatform       food.FoodType `json:"FoodOnPlatform"`
+	FoodPerAgentRatio    int           `json:"FoodPerAgentRatio"`
+	UseFoodPerAgentRatio bool          `json:"UseFoodPerAgentRatio"`
+	Team1AgtOne          int           `json:"Team1AgtOne"`
+	Team1AgtTwo          int           `json:"Team1AgtTwo"`
+	Team2Agents          int           `json:"Team2Agents"`
+	Team3Agents          int           `json:"Team3Agents"`
+	Team4Agents          int           `json:"Team4Agents"`
+	Team5Agents          int           `json:"Team5Agents"`
+	Team6Agents          int           `json:"Team6Agents"`
+	Team7Agent1          int           `json:"Team7Agent1"`
+	RandomAgents         int           `json:"RandomAgents"`
+	AgentHP              int           `json:"AgentHP"`
+	AgentsPerFloor       int           `json:"AgentsPerFloor"`
+	TicksPerFloor        int           `json:"TicksPerFloor"`
+	SimDays              int           `json:"SimDays"`
+	ReshuffleDays        int           `json:"ReshuffleDays"`
+	MaxHP                int           `json:"maxHP"`
+	WeakLevel            int           `json:"weakLevel"`
+	Width                float64       `json:"width"`
+	Tau                  float64       `json:"tau"`
+	HpReqCToW            int           `json:"hpReqCToW"`
+	HpCritical           int           `json:"hpCritical"`
+	MaxDayCritical       int           `json:"maxDayCritical"`
+	HPLossBase           int           `json:"HPLossBase"`
+	HPLossSlope          float64       `json:"HPLossSlope"`
+	LogFileName          string        `json:"LogFileName"`
+	LogMain              bool          `json:"LogMain"`
+	NumOfAgents          []int
+	NumberOfFloors       int
+	TicksPerDay          int
+	DayInfo              *day.DayInfo
 }
 
 type Response struct { // used for HTTP response
@@ -108,6 +110,10 @@ func CalculateDependentParameters(parameters *ConfigParameters) error {
 		return err
 	}
 
+	if parameters.UseFoodPerAgentRatio {
+		parameters.FoodOnPlatform = food.FoodType(parameters.FoodPerAgentRatio * utilFunctions.Sum(parameters.NumOfAgents))
+	}
+
 	//do the calculations for parameters that depend on other parameters
 	parameters.NumberOfFloors = utilFunctions.Sum(parameters.NumOfAgents) / parameters.AgentsPerFloor
 	parameters.TicksPerDay = parameters.NumberOfFloors * parameters.TicksPerFloor
@@ -120,8 +126,16 @@ func CalculateDependentParameters(parameters *ConfigParameters) error {
 //This can happen if they are missing from the json config / http request, as they'd all be initialised to 0 / nil
 func CheckParametersAreValid(parameters *ConfigParameters) error {
 
-	if parameters.FoodOnPlatform == 0 {
-		return errors.New("foodOnPlatform not initialised or set to 0")
+	//Checking that Food amount is valid
+
+	if parameters.UseFoodPerAgentRatio {
+		if parameters.FoodPerAgentRatio == 0 {
+			return errors.New("foodPerAgentRatio not initialised or set to 0")
+		}
+	} else {
+		if parameters.FoodOnPlatform == 0 {
+			return errors.New("foodOnPlatform not initialised or set to 0")
+		}
 	}
 
 	if utilFunctions.Sum(parameters.NumOfAgents) == 0 {

--- a/pkg/simulation/simAgent.go
+++ b/pkg/simulation/simAgent.go
@@ -53,10 +53,10 @@ func (sE *SimEnv) replaceAgents(t *infra.Tower) {
 		agent := agent.BaseAgent()
 		if !agent.IsAlive() {
 			delete(t.Agents, uuid)
+			sE.stateLog.LogAgentDeath(sE.dayInfo.CurrDay, sE.dayInfo.CurrTick, agent.AgentType())
 			sE.Log("An Agent has died", infra.Fields{"agent_type": agent.AgentType()})
 			t.UpdateDeadAgents(agent.AgentType())
 			sE.createNewAgent(t, agent.AgentType(), agent.Floor())
-
 		}
 	}
 }

--- a/pkg/simulation/simIteration.go
+++ b/pkg/simulation/simIteration.go
@@ -26,6 +26,7 @@ func (sE *SimEnv) simulationLoop(t *infra.Tower) {
 		sE.AgentsRun(t)
 		sE.TowerTick()
 		sE.replaceAgents(t)
+		t.TowerStateLog(" end of tick")
 		sE.dayInfo.CurrTick++
 	}
 }

--- a/pkg/simulation/simulation.go
+++ b/pkg/simulation/simulation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/food"
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/health"
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/world"
+	"github.com/SOMAS2021/SOMAS2021/pkg/utils/logging"
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/utilFunctions"
 	log "github.com/sirupsen/logrus"
 )
@@ -22,6 +23,7 @@ type SimEnv struct {
 	dayInfo        *day.DayInfo
 	healthInfo     *health.HealthInfo
 	world          world.World
+	stateLog       *logging.StateLog
 }
 
 func NewSimEnv(parameters *config.ConfigParameters, healthInfo *health.HealthInfo) *SimEnv {
@@ -33,6 +35,7 @@ func NewSimEnv(parameters *config.ConfigParameters, healthInfo *health.HealthInf
 		healthInfo:     healthInfo,
 		AgentsPerFloor: parameters.AgentsPerFloor,
 		logger:         *log.WithFields(log.Fields{"reporter": "simulation"}),
+		stateLog:       logging.NewLogState(parameters.LogFileName),
 	}
 }
 
@@ -40,7 +43,7 @@ func (sE *SimEnv) Simulate() {
 	sE.Log("Simulation Initializing")
 
 	totalAgents := utilFunctions.Sum(sE.AgentCount)
-	t := infra.NewTower(sE.FoodOnPlatform, totalAgents, sE.AgentsPerFloor, sE.dayInfo, sE.healthInfo)
+	t := infra.NewTower(sE.FoodOnPlatform, totalAgents, sE.AgentsPerFloor, sE.dayInfo, sE.healthInfo, sE.stateLog)
 	sE.SetWorld(t)
 
 	sE.generateInitialAgents(t)

--- a/pkg/utils/globalTypes/day/day.go
+++ b/pkg/utils/globalTypes/day/day.go
@@ -8,6 +8,7 @@ type DayInfo struct {
 	TicksPerReshuffle int
 	TotalTicks        int
 	CurrTick          int
+	CurrDay           int
 }
 
 func NewDayInfo(TicksPerFloor, TicksPerDay, SimulationDays, DaysPerReshuffle int) *DayInfo {
@@ -19,5 +20,6 @@ func NewDayInfo(TicksPerFloor, TicksPerDay, SimulationDays, DaysPerReshuffle int
 		TicksPerReshuffle: TicksPerDay * DaysPerReshuffle,
 		TotalTicks:        TicksPerDay * SimulationDays,
 		CurrTick:          1,
+		CurrDay:           1,
 	}
 }

--- a/pkg/utils/logging/logging.go
+++ b/pkg/utils/logging/logging.go
@@ -1,0 +1,51 @@
+package logging
+
+import (
+	"os"
+	"path/filepath"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// struct definition
+type LogManager struct {
+	loggers    map[string]*log.Logger
+	folderPath string
+}
+
+// constructor
+func NewLogger(folderPath string) LogManager {
+	var myLogger LogManager
+	myLogger.loggers = map[string]*log.Logger{}
+	myLogger.folderPath = folderPath
+	return myLogger
+}
+
+// adding a new logger
+func (L *LogManager) AddLogger(key string, logpath string) (logger *log.Logger, err error) {
+	Logger := log.New()
+	_, exists := L.loggers[key]
+	if exists {
+		return nil, os.ErrExist
+	}
+	file, err := os.OpenFile(filepath.Join(L.folderPath, logpath), os.O_CREATE|os.O_RDWR, 0666)
+	if err != nil {
+		return nil, err
+	}
+	Logger.SetOutput(file)
+	Logger.SetFormatter(&log.JSONFormatter{})
+	L.loggers[key] = Logger
+	return Logger, err
+}
+
+// getting an existing logger
+func (L *LogManager) GetLogger(key string) *log.Logger {
+	if L.loggers == nil {
+		return nil
+	}
+	logger, exists := L.loggers[key]
+	if exists {
+		return logger
+	}
+	return nil
+}

--- a/pkg/utils/logging/statelog.go
+++ b/pkg/utils/logging/statelog.go
@@ -1,0 +1,49 @@
+package logging
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type StateLog struct {
+	logmanager *LogManager
+	// Loggers
+	foodLogger  *log.Logger
+	deathLogger *log.Logger
+	// Death state
+	deathCount int
+}
+
+func handleNewLoggerErr(err error) {
+	if err != nil {
+		fmt.Println("error creating new logger: ", err)
+	}
+}
+
+func NewLogState(folderpath string) *StateLog {
+	// init manager
+	l := NewLogger(folderpath)
+
+	// new loggers
+	foodLogger, err := l.AddLogger("food", "food.json")
+	handleNewLoggerErr(err)
+	deathLogger, err := l.AddLogger("death", "death.json")
+	handleNewLoggerErr(err)
+
+	return &StateLog{
+		logmanager:  &l,
+		foodLogger:  foodLogger,
+		deathLogger: deathLogger,
+		deathCount:  0,
+	}
+}
+
+func (ls *StateLog) LogAgentDeath(day int, tick int, agentType int) {
+	ls.deathCount++
+	ls.deathLogger.WithFields(log.Fields{"day": day, "tick": tick, "agent_type": agentType, "cumulativeDeaths": ls.deathCount}).Info("")
+}
+
+func (ls *StateLog) LogPlatFoodState(day int, tick int, food int) {
+	ls.foodLogger.WithFields(log.Fields{"day": day, "tick": tick, "food": food}).Info("")
+}


### PR DESCRIPTION
Closes #175 

Added `UseFoodPerAgentRatio` and `FoodPerAgentRatio` config parameters to allow to automatically set the amount of food depending on the number of agents. 

If `UseFoodPerAgentRatio` is true, then it multiplies `FoodPerAgentRatio` by number of agents to calculate total food. It ignores the `FoodOnPlatform` parameter if it is set

If  `UseFoodPerAgentRatio` is false, then it uses `FoodOnPlatform` and ignores `FoodPerAgentRatio`

I updated the config.json to include default parameters for them, and added error handling in case any of these three parameters are not set correctly.

