### PR TITLE
Add PlatOnFloor function for agents

### DIFF
--- a/pkg/agents/randomAgent/agent.go
+++ b/pkg/agents/randomAgent/agent.go
@@ -20,5 +20,13 @@ func New(baseAgent *infra.Base) (infra.Agent, error) {
 
 func (a *CustomAgentRandom) Run() {
 	a.Log("Random agent reporting status:", infra.Fields{"floor": a.Floor(), "hp": a.HP()})
-	a.TakeFood(food.FoodType(rand.Intn(100)))
+	_, err := a.TakeFood(food.FoodType(rand.Intn(100)))
+	if err != nil {
+		switch err.(type) {
+		case *infra.FloorError:
+		case *infra.NegFoodError:
+		case *infra.AlreadyEatenError:
+		default:
+		}
+	}
 }

--- a/pkg/agents/team1/agent1/agent.go
+++ b/pkg/agents/team1/agent1/agent.go
@@ -65,7 +65,15 @@ func (a *CustomAgent1) Run() {
 		a.Log("I sent a message", infra.Fields{"message": "StateIntendedFoodIntake"})
 	}
 	a.Log("My agent is doing something", infra.Fields{"thing": "potatoe", "another_thing": "another potatoe"})
-	a.TakeFood(16)
+	_, err := a.TakeFood(16)
+	if err != nil {
+		switch err.(type) {
+		case *infra.FloorError:
+		case *infra.NegFoodError:
+		case *infra.AlreadyEatenError:
+		default:
+		}
+	}
 }
 
 func (a *CustomAgent1) HandleAskHP(msg messages.AskHPMessage) {

--- a/pkg/agents/team1/agent2/agent.go
+++ b/pkg/agents/team1/agent2/agent.go
@@ -20,7 +20,15 @@ func New(baseAgent *infra.Base) (infra.Agent, error) {
 
 func (a *CustomAgent2) Run() {
 	a.Log("Custom agent reporting status without using fields")
-	a.TakeFood(15)
+	_, err := a.TakeFood(15)
+	if err != nil {
+		switch err.(type) {
+		case *infra.FloorError:
+		case *infra.NegFoodError:
+		case *infra.AlreadyEatenError:
+		default:
+		}
+	}
 	receivedMsg := a.ReceiveMessage()
 	if receivedMsg != nil {
 		receivedMsg.Visit(a)

--- a/pkg/agents/team2/config.go
+++ b/pkg/agents/team2/config.go
@@ -114,7 +114,15 @@ func (a *CustomAgent2) Run() {
 		oldHP := a.HP()
 		a.Log("Agent team2 before action:", infra.Fields{"floor": a.Floor(), "hp": oldHP, "food": a.CurrPlatFood(), "state": oldState})
 		action := a.SelectAction()
-		a.TakeFood(a.actionSpace.actionSet[action](oldHP)) //perform selected action
+		_, err := a.TakeFood(a.actionSpace.actionSet[action](oldHP)) //perform selected action
+		if err != nil {
+			switch err.(type) {
+			case *infra.FloorError:
+			case *infra.NegFoodError:
+			case *infra.AlreadyEatenError:
+			default:
+			}
+		}
 		a.Log("Agent team2:", infra.Fields{"selected and performed action": action})
 		a.Log("Agent team2 after action:", infra.Fields{"floor": a.Floor(), "hp": a.HP(), "food": a.CurrPlatFood(), "state": a.CheckState()})
 		hpInc := a.HP() - oldHP

--- a/pkg/agents/team3/agentMain.go
+++ b/pkg/agents/team3/agentMain.go
@@ -59,8 +59,15 @@ func (a *CustomAgent3) Run() {
 	//receive Message
 
 	//eat
-	a.TakeFood(takeFoodCalculation(a))
-
+	_, err := a.TakeFood(takeFoodCalculation(a))
+	if err != nil {
+		switch err.(type) {
+		case *infra.FloorError:
+		case *infra.NegFoodError:
+		case *infra.AlreadyEatenError:
+		default:
+		}
+	}
 	//send Message
 
 }

--- a/pkg/agents/team4/agent1/agent.go
+++ b/pkg/agents/team4/agent1/agent.go
@@ -92,7 +92,15 @@ func (a *CustomAgentEvo) Run() {
 	scaledHpScore := a.params.currentHpScore.EvaluateEquation(a.HP()) / a.params.scalingEquation.EvaluateEquation(a.HP())
 	foodToEat := food.FoodType(math.Max(0.0, 50*scaledFloorScore+50*scaledHpScore))
 
-	foodEaten := a.TakeFood(foodToEat)
+	foodEaten, err := a.TakeFood(foodToEat)
+	if err != nil {
+		switch err.(type) {
+		case *infra.FloorError:
+		case *infra.NegFoodError:
+		case *infra.AlreadyEatenError:
+		default:
+		}
+	}
 
 	a.Log("team4EvoAgent reporting status:", infra.Fields{"floor": a.Floor(), "hp": a.HP(), "foodToEat": foodToEat, "foodEaten": foodEaten, "currentFloorScore": a.params.currentFloorScore.coefficients, "currentHpScore": a.params.currentHpScore.coefficients})
 

--- a/pkg/agents/team5/agent1/agent.go
+++ b/pkg/agents/team5/agent1/agent.go
@@ -157,7 +157,16 @@ func (a *CustomAgent5) Run() {
 	}
 	//When platform reaches our floor and we haven't tried to eat, then try to eat
 	if a.CurrPlatFood() != -1 && a.attemptToEat {
-		a.lastMeal = a.TakeFood(attemptFood)
+		lastMeal, err := a.TakeFood(attemptFood)
+		if err != nil {
+			switch err.(type) {
+			case *infra.FloorError:
+			case *infra.NegFoodError:
+			case *infra.AlreadyEatenError:
+			default:
+			}
+		}
+		a.lastMeal = lastMeal
 		if a.lastMeal > 0 {
 			a.Log("Team 5 agent has taken food", infra.Fields{"amount": a.lastMeal})
 			a.daysSinceLastMeal = 0

--- a/pkg/agents/team6/config.go
+++ b/pkg/agents/team6/config.go
@@ -93,7 +93,15 @@ func (a *CustomAgent6) Run() {
 	// a.Log("Custom agent 6 after update:", infra.Fields{"floor": a.Floor(), "hp": a.HP(), "behaviour": a.currBehaviour.String(), "maxFloorGuess": a.maxFloorGuess})
 
 	foodAmount := a.foodIntake()
-	a.TakeFood(foodAmount)
+	_, err := a.TakeFood(foodAmount)
+	if err != nil {
+		switch err.(type) {
+		case *infra.FloorError:
+		case *infra.NegFoodError:
+		case *infra.AlreadyEatenError:
+		default:
+		}
+	}
 	a.Log("Team 6 took:", infra.Fields{"foodTaken": foodAmount, "bType": a.currBehaviour.String()})
 	a.Log("Team 6 agent has HP:", infra.Fields{"hp": a.HP()})
 

--- a/pkg/agents/team7/agent1/agent.go
+++ b/pkg/agents/team7/agent1/agent.go
@@ -1,9 +1,10 @@
 package team7agent1
 
 import (
+	"math/rand"
+
 	"github.com/SOMAS2021/SOMAS2021/pkg/infra"
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/food"
-	"math/rand"
 )
 
 /*
@@ -144,7 +145,16 @@ func (a *CustomAgent7) Run() {
 
 		//has the agent seen the platform
 		if a.CurrPlatFood() != -1 && !a.seenPlatform {
-			a.foodEaten = a.TakeFood(foodtotake)
+			foodEaten, err := a.TakeFood(foodtotake)
+			if err != nil {
+				switch err.(type) {
+				case *infra.FloorError:
+				case *infra.NegFoodError:
+				case *infra.AlreadyEatenError:
+				default:
+				}
+			}
+			a.foodEaten = foodEaten
 			if a.foodEaten > 0 {
 				a.daysHungry = 0
 			} else {

--- a/pkg/infra/baseagent.go
+++ b/pkg/infra/baseagent.go
@@ -179,19 +179,20 @@ func (a *Base) setHasEaten(newStatus bool) {
 	a.hasEaten = newStatus
 }
 
+func (a *Base) PlatformOnFloor() bool {
+	return a.floor == a.tower.currPlatFloor
+}
+
 func (a *Base) TakeFood(amountOfFood food.FoodType) food.FoodType {
-	if amountOfFood == 0 {
+	if a.floor != a.tower.currPlatFloor || a.hasEaten || amountOfFood <= 0 {
 		return 0
 	}
-	if a.floor == a.tower.currPlatFloor && !a.hasEaten && amountOfFood > 0 {
-		foodTaken := food.FoodType(math.Min(float64(a.tower.currPlatFood), float64(amountOfFood)))
-		a.updateHP(foodTaken)
-		a.tower.currPlatFood -= foodTaken
-		a.setHasEaten(foodTaken > 0)
-		a.Log("An agent has taken food", Fields{"floor": a.floor, "amount": foodTaken})
-		return foodTaken
-	}
-	return -1
+	foodTaken := food.FoodType(math.Min(float64(a.tower.currPlatFood), float64(amountOfFood)))
+	a.updateHP(foodTaken)
+	a.tower.currPlatFood -= foodTaken
+	a.setHasEaten(foodTaken > 0)
+	a.Log("An agent has taken food", Fields{"floor": a.floor, "amount": foodTaken})
+	return foodTaken
 }
 
 func (a *Base) ReceiveMessage() messages.Message {

--- a/pkg/infra/baseagent.go
+++ b/pkg/infra/baseagent.go
@@ -183,16 +183,22 @@ func (a *Base) PlatformOnFloor() bool {
 	return a.floor == a.tower.currPlatFloor
 }
 
-func (a *Base) TakeFood(amountOfFood food.FoodType) food.FoodType {
-	if a.floor != a.tower.currPlatFloor || a.hasEaten || amountOfFood <= 0 {
-		return 0
+func (a *Base) TakeFood(amountOfFood food.FoodType) (food.FoodType, error) {
+	if a.floor != a.tower.currPlatFloor {
+		return 0, &FloorError{}
+	}
+	if a.hasEaten {
+		return 0, &AlreadyEatenError{}
+	}
+	if amountOfFood < 0 {
+		return 0, &NegFoodError{}
 	}
 	foodTaken := food.FoodType(math.Min(float64(a.tower.currPlatFood), float64(amountOfFood)))
 	a.updateHP(foodTaken)
 	a.tower.currPlatFood -= foodTaken
 	a.setHasEaten(foodTaken > 0)
 	a.Log("An agent has taken food", Fields{"floor": a.floor, "amount": foodTaken})
-	return foodTaken
+	return foodTaken, nil
 }
 
 func (a *Base) ReceiveMessage() messages.Message {

--- a/pkg/infra/baseagent_errors.go
+++ b/pkg/infra/baseagent_errors.go
@@ -1,0 +1,17 @@
+package infra
+
+type FloorError struct{}
+type NegFoodError struct{}
+type AlreadyEatenError struct{}
+
+func (e *FloorError) Error() string {
+	return "platform is not on your floor"
+}
+
+func (e *NegFoodError) Error() string {
+	return "cannot take negative food"
+}
+
+func (e *AlreadyEatenError) Error() string {
+	return "already eaten today"
+}


### PR DESCRIPTION
# Summary

Add PlatOnFloor function to tell agents 

Fix design to only return foodTaken, not tower states (so no more -1 returned)


Edit from Jason: `TakeFood()` now returns two values, a `food.FoodType` and an `error`. `food.FoodType` is how much food an agent actually managed to take, and if `err != nil` then something went wrong - either you have already eaten, the platform is not on your floor, or you entered a negative amount of food to take.