### PR TITLE
Added Timeout functionality

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,7 @@
 {
+    "UseFoodPerAgentRatio": false,
     "FoodOnPlatform": 100,
+    "FoodPerAgentRatio": 0,
     "Team1AgtOne": 2,
     "Team1AgtTwo": 2,
     "Team2Agents": 2,

--- a/config.json
+++ b/config.json
@@ -25,5 +25,6 @@
     "maxDayCritical": 3,
     "HPLossBase": 10,
     "HPLossSlope": 0.25,
-    "LogMain": true
+    "LogMain": true,
+    "SimTimeoutSeconds": 60
 }

--- a/main.go
+++ b/main.go
@@ -38,14 +38,31 @@ func main() {
 			}
 
 			// logFileName returned to be used in dashboard
-			logfileName := runNewSimulation(parameters)
+			logFileName := ""
+
+			//channel and goroutine used for timeouts
+			c1 := make(chan string, 1)
+
+			go func() {
+				filenametemp := runNewSimulation(parameters)
+				c1 <- filenametemp
+			}()
+
+			// Listen on our channel AND a timeout channel - which ever happens first.
+			select {
+			case res := <-c1:
+				logFileName = res
+			case <-time.After(time.Duration(parameters.SimTimeoutSeconds) * time.Second):
+
+				http.Error(w, "Simulation Timeout", http.StatusInternalServerError)
+				return
+			}
 
 			//generate the http response
 			w.Header().Set("Content-Type", "application/json")
 
 			response := config.Response{
-				Success:     true, // this will depend on timeouts in the future, for now it is hardcoded until i figure out how timeouts work
-				LogFileName: logfileName,
+				LogFileName: logFileName,
 			}
 			err = json.NewEncoder(w).Encode(response)
 			if err != nil {
@@ -67,7 +84,22 @@ func main() {
 			return
 		}
 
-		runNewSimulation(parameters)
+		//channel and goroutine used for timeout
+		c1 := make(chan string, 1)
+
+		go func() {
+			filenametemp := runNewSimulation(parameters)
+			c1 <- filenametemp
+		}()
+
+		// Listen on our channel AND a timeout channel - which ever happens first.
+		select {
+		case <-c1:
+			fmt.Println("Simulation Finished Successfully")
+		case <-time.After(time.Duration(parameters.SimTimeoutSeconds) * time.Second):
+			fmt.Println("Simulation Timeout")
+			log.Fatal("Simulation Timeout")
+		}
 	}
 }
 

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -41,6 +41,7 @@ type ConfigParameters struct {
 	HPLossSlope          float64       `json:"HPLossSlope"`
 	LogFileName          string        `json:"LogFileName"`
 	LogMain              bool          `json:"LogMain"`
+	SimTimeoutSeconds    int           `json:"SimTimeoutSeconds"`
 	NumOfAgents          []int
 	NumberOfFloors       int
 	TicksPerDay          int
@@ -48,9 +49,7 @@ type ConfigParameters struct {
 }
 
 type Response struct { // used for HTTP response
-	Success     bool   `json:"Success"`
 	LogFileName string `json:"LogFileName"`
-	Error       string `json:"Error"`
 }
 
 func LoadParamFromJson(path string) (ConfigParameters, error) {
@@ -197,5 +196,10 @@ func CheckParametersAreValid(parameters *ConfigParameters) error {
 	if parameters.HPLossSlope == 0 {
 		return errors.New("hpLossSlope not initialised or set to 0")
 	}
+
+	if parameters.SimTimeoutSeconds == 0 {
+		return errors.New("SimTimeoutSeconds not initialised or set to 0")
+	}
+
 	return nil
 }

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -13,36 +13,38 @@ import (
 )
 
 type ConfigParameters struct {
-	FoodOnPlatform food.FoodType `json:"FoodOnPlatform"`
-	Team1AgtOne    int           `json:"Team1AgtOne"`
-	Team1AgtTwo    int           `json:"Team1AgtTwo"`
-	Team2Agents    int           `json:"Team2Agents"`
-	Team3Agents    int           `json:"Team3Agents"`
-	Team4Agents    int           `json:"Team4Agents"`
-	Team5Agents    int           `json:"Team5Agents"`
-	Team6Agents    int           `json:"Team6Agents"`
-	Team7Agent1    int           `json:"Team7Agent1"`
-	RandomAgents   int           `json:"RandomAgents"`
-	AgentHP        int           `json:"AgentHP"`
-	AgentsPerFloor int           `json:"AgentsPerFloor"`
-	TicksPerFloor  int           `json:"TicksPerFloor"`
-	SimDays        int           `json:"SimDays"`
-	ReshuffleDays  int           `json:"ReshuffleDays"`
-	MaxHP          int           `json:"maxHP"`
-	WeakLevel      int           `json:"weakLevel"`
-	Width          float64       `json:"width"`
-	Tau            float64       `json:"tau"`
-	HpReqCToW      int           `json:"hpReqCToW"`
-	HpCritical     int           `json:"hpCritical"`
-	MaxDayCritical int           `json:"maxDayCritical"`
-	HPLossBase     int           `json:"HPLossBase"`
-	HPLossSlope    float64       `json:"HPLossSlope"`
-	LogFileName    string        `json:"LogFileName"`
-	LogMain        bool          `json:"LogMain"`
-	NumOfAgents    []int
-	NumberOfFloors int
-	TicksPerDay    int
-	DayInfo        *day.DayInfo
+	FoodOnPlatform       food.FoodType `json:"FoodOnPlatform"`
+	FoodPerAgentRatio    int           `json:"FoodPerAgentRatio"`
+	UseFoodPerAgentRatio bool          `json:"UseFoodPerAgentRatio"`
+	Team1AgtOne          int           `json:"Team1AgtOne"`
+	Team1AgtTwo          int           `json:"Team1AgtTwo"`
+	Team2Agents          int           `json:"Team2Agents"`
+	Team3Agents          int           `json:"Team3Agents"`
+	Team4Agents          int           `json:"Team4Agents"`
+	Team5Agents          int           `json:"Team5Agents"`
+	Team6Agents          int           `json:"Team6Agents"`
+	Team7Agent1          int           `json:"Team7Agent1"`
+	RandomAgents         int           `json:"RandomAgents"`
+	AgentHP              int           `json:"AgentHP"`
+	AgentsPerFloor       int           `json:"AgentsPerFloor"`
+	TicksPerFloor        int           `json:"TicksPerFloor"`
+	SimDays              int           `json:"SimDays"`
+	ReshuffleDays        int           `json:"ReshuffleDays"`
+	MaxHP                int           `json:"maxHP"`
+	WeakLevel            int           `json:"weakLevel"`
+	Width                float64       `json:"width"`
+	Tau                  float64       `json:"tau"`
+	HpReqCToW            int           `json:"hpReqCToW"`
+	HpCritical           int           `json:"hpCritical"`
+	MaxDayCritical       int           `json:"maxDayCritical"`
+	HPLossBase           int           `json:"HPLossBase"`
+	HPLossSlope          float64       `json:"HPLossSlope"`
+	LogFileName          string        `json:"LogFileName"`
+	LogMain              bool          `json:"LogMain"`
+	NumOfAgents          []int
+	NumberOfFloors       int
+	TicksPerDay          int
+	DayInfo              *day.DayInfo
 }
 
 type Response struct { // used for HTTP response
@@ -108,6 +110,10 @@ func CalculateDependentParameters(parameters *ConfigParameters) error {
 		return err
 	}
 
+	if parameters.UseFoodPerAgentRatio {
+		parameters.FoodOnPlatform = food.FoodType(parameters.FoodPerAgentRatio * utilFunctions.Sum(parameters.NumOfAgents))
+	}
+
 	//do the calculations for parameters that depend on other parameters
 	parameters.NumberOfFloors = utilFunctions.Sum(parameters.NumOfAgents) / parameters.AgentsPerFloor
 	parameters.TicksPerDay = parameters.NumberOfFloors * parameters.TicksPerFloor
@@ -120,8 +126,16 @@ func CalculateDependentParameters(parameters *ConfigParameters) error {
 //This can happen if they are missing from the json config / http request, as they'd all be initialised to 0 / nil
 func CheckParametersAreValid(parameters *ConfigParameters) error {
 
-	if parameters.FoodOnPlatform == 0 {
-		return errors.New("foodOnPlatform not initialised or set to 0")
+	//Checking that Food amount is valid
+
+	if parameters.UseFoodPerAgentRatio {
+		if parameters.FoodPerAgentRatio == 0 {
+			return errors.New("foodPerAgentRatio not initialised or set to 0")
+		}
+	} else {
+		if parameters.FoodOnPlatform == 0 {
+			return errors.New("foodOnPlatform not initialised or set to 0")
+		}
 	}
 
 	if utilFunctions.Sum(parameters.NumOfAgents) == 0 {

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -13,7 +13,6 @@ import (
 )
 
 type ConfigParameters struct {
-<<<<<<< HEAD
 	FoodOnPlatform       food.FoodType `json:"FoodOnPlatform"`
 	FoodPerAgentRatio    int           `json:"FoodPerAgentRatio"`
 	UseFoodPerAgentRatio bool          `json:"UseFoodPerAgentRatio"`
@@ -47,39 +46,6 @@ type ConfigParameters struct {
 	NumberOfFloors       int
 	TicksPerDay          int
 	DayInfo              *day.DayInfo
-=======
-	FoodOnPlatform    food.FoodType `json:"FoodOnPlatform"`
-	Team1AgtOne       int           `json:"Team1AgtOne"`
-	Team1AgtTwo       int           `json:"Team1AgtTwo"`
-	Team2Agents       int           `json:"Team2Agents"`
-	Team3Agents       int           `json:"Team3Agents"`
-	Team4Agents       int           `json:"Team4Agents"`
-	Team5Agents       int           `json:"Team5Agents"`
-	Team6Agents       int           `json:"Team6Agents"`
-	Team7Agent1       int           `json:"Team7Agent1"`
-	RandomAgents      int           `json:"RandomAgents"`
-	AgentHP           int           `json:"AgentHP"`
-	AgentsPerFloor    int           `json:"AgentsPerFloor"`
-	TicksPerFloor     int           `json:"TicksPerFloor"`
-	SimDays           int           `json:"SimDays"`
-	ReshuffleDays     int           `json:"ReshuffleDays"`
-	MaxHP             int           `json:"maxHP"`
-	WeakLevel         int           `json:"weakLevel"`
-	Width             float64       `json:"width"`
-	Tau               float64       `json:"tau"`
-	HpReqCToW         int           `json:"hpReqCToW"`
-	HpCritical        int           `json:"hpCritical"`
-	MaxDayCritical    int           `json:"maxDayCritical"`
-	HPLossBase        int           `json:"HPLossBase"`
-	HPLossSlope       float64       `json:"HPLossSlope"`
-	LogFileName       string        `json:"LogFileName"`
-	LogMain           bool          `json:"LogMain"`
-	SimTimeoutSeconds int           `json:"SimTimeoutSeconds"`
-	NumOfAgents       []int
-	NumberOfFloors    int
-	TicksPerDay       int
-	DayInfo           *day.DayInfo
->>>>>>> 47bc22f9027d7a376d4524292923731000fb7ec2
 }
 
 type Response struct { // used for HTTP response


### PR DESCRIPTION
Closes #142

Added a parameter `SimTimeoutSeconds` to limit the amount of time used for simulation, and return an error if it is exceeded. 

If it is running in serve mode, if timeout is exceeded then it will return a HTTP 500 Internal Server Error with a timeout message, as seen below


<details>
  <summary> Timeout error in serve mode </summary>

![image](https://user-images.githubusercontent.com/56606852/147824552-0fd1c6e3-e2aa-47ba-b7eb-c50e5154c11d.png)

</details>



If it is running in a single simulation mode, if timeout is exceeded it both prints that there was a timeout error and appends it to the log (unsure if I should handle it differently, let me know if there is a better way)