### PR TITLE
Infra directory endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -61,12 +62,38 @@ func main() {
 			//generate the http response
 			w.Header().Set("Content-Type", "application/json")
 
-			response := config.Response{
+			response := config.SimulateResponse{
 				LogFileName: logFileName,
 			}
 			err = json.NewEncoder(w).Encode(response)
 			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		})
+		http.HandleFunc("/directory", func(w http.ResponseWriter, r *http.Request) {
+			//read directory
+			files, err := ioutil.ReadDir("./logs")
+			if err != nil {
+				http.Error(w, "Unable to open logs folder. There might not be any logs created yet", http.StatusInternalServerError)
+				return
+			}
+			for _, f := range files {
+				fmt.Println(f.Name())
+			}
+
+			//put them all in a struct
+			var response config.DirectoryResponse
+
+			for _, f := range files {
+				response.FolderNames = append(response.FolderNames, f.Name())
+			}
+
+			//convert struct to json and return the response
+
+			err = json.NewEncoder(w).Encode(response)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 		})

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -49,8 +49,12 @@ type ConfigParameters struct {
 	DayInfo              *day.DayInfo
 }
 
-type Response struct { // used for HTTP response
+type SimulateResponse struct { // used for HTTP response on /simulate
 	LogFileName string `json:"LogFileName"`
+}
+
+type DirectoryResponse struct { // used for HTTP response on /directory
+	FolderNames []string `json:"FolderNames"`
 }
 
 func LoadParamFromJson(path string) (ConfigParameters, error) {


### PR DESCRIPTION
Closes #171 

When the application runs in serve mode, it will now also listen to the /directory endpoint, and when it receives a request, it will return a list of all the existing folders inside the log folder:

<details>
  <summary> /directory request </summary>

![image](https://user-images.githubusercontent.com/56606852/147835123-4b4b809a-c893-457b-a458-42f955843de3.png)

</details>

If the folder does not exist, it returns a HTTP 500 Internal Server Error with an error message:

<details>
  <summary> /directory request with no log folder existing </summary>

![image](https://user-images.githubusercontent.com/56606852/147835102-a061bdc6-8fd1-41d1-8380-6dfe91d1e040.png)

</details>

Also an additional change was to return the error resulted by being unable to put the result struct into json format for the response in the /simulate endpoint from 400 Bad Request to 500 Internal Server Error.
