### PR TITLE
Infra/propogate messages

### DIFF
--- a/pkg/agents/team1/agent1/agent.go
+++ b/pkg/agents/team1/agent1/agent.go
@@ -33,35 +33,35 @@ func (a *CustomAgent1) Run() {
 	switch r {
 	case 0:
 		msg := messages.NewAskFoodTakenMessage(a.ID(), a.Floor(), a.Floor()-2)
-		a.SendMessage(-1, msg)
+		a.SendMessage(msg)
 		a.Log("I sent a message", infra.Fields{"message": "AskFoodTaken", "floor": a.Floor()})
 	case 1:
 		msg := messages.NewAskHPMessage(a.ID(), a.Floor(), a.Floor()+3)
-		a.SendMessage(1, msg)
+		a.SendMessage(msg)
 		a.Log("I sent a message", infra.Fields{"message": "AskHP", "floor": a.Floor()})
 	case 2:
 		msg := messages.NewAskIntendedFoodIntakeMessage(a.ID(), a.Floor(), a.Floor()+2)
-		a.SendMessage(1, msg)
+		a.SendMessage(msg)
 		a.Log("I sent a message", infra.Fields{"message": "AskIntendedFoodIntake", "floor": a.Floor()})
 	case 3:
 		msg := messages.NewRequestLeaveFoodMessage(a.ID(), a.Floor(), a.Floor()+1, 10)
-		a.SendMessage(1, msg)
+		a.SendMessage(msg)
 		a.Log("I sent a message", infra.Fields{"message": "RequestLeaveFood", "floor": a.Floor()})
 	case 4:
 		msg := messages.NewRequestTakeFoodMessage(a.ID(), a.Floor(), a.Floor()-3, 20)
-		a.SendMessage(-1, msg)
+		a.SendMessage(msg)
 		a.Log("I sent a message", infra.Fields{"message": "RequestTakeFood", "floor": a.Floor()})
 	case 5:
 		msg := messages.NewStateFoodTakenMessage(a.ID(), a.Floor(), a.Floor()+2, 30)
-		a.SendMessage(1, msg)
+		a.SendMessage(msg)
 		a.Log("I sent a message", infra.Fields{"message": "StateFoodTaken", "floor": a.Floor()})
 	case 6:
 		msg := messages.NewStateHPMessage(a.ID(), a.Floor(), a.Floor()-1, 40)
-		a.SendMessage(-1, msg)
+		a.SendMessage(msg)
 		a.Log("I sent a message", infra.Fields{"message": "StateHP", "floor": a.Floor()})
 	case 7:
 		msg := messages.NewStateIntendedFoodIntakeMessage(a.ID(), a.Floor(), a.Floor()+3, 50)
-		a.SendMessage(1, msg)
+		a.SendMessage(msg)
 		a.Log("I sent a message", infra.Fields{"message": "StateIntendedFoodIntake", "floor": a.Floor()})
 	}
 	a.Log("My agent is doing something", infra.Fields{"thing": "potatoe", "another_thing": "another potatoe"})
@@ -78,51 +78,31 @@ func (a *CustomAgent1) Run() {
 
 func (a *CustomAgent1) HandleAskHP(msg messages.AskHPMessage) {
 	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), a.HP())
-	direction := 1
-	if a.Floor() > msg.TargetFloor() {
-		direction = -1
-	}
-	a.SendMessage(direction, reply)
+	a.SendMessage(reply)
 	a.Log("I recieved an askHP message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent1) HandleAskFoodTaken(msg messages.AskFoodTakenMessage) {
 	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), 10)
-	direction := 1
-	if a.Floor() > msg.TargetFloor() {
-		direction = -1
-	}
-	a.SendMessage(direction, reply)
+	a.SendMessage(reply)
 	a.Log("I recieved an askFoodTaken message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent1) HandleAskIntendedFoodTaken(msg messages.AskIntendedFoodIntakeMessage) {
 	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), 11)
-	direction := 1
-	if a.Floor() > msg.TargetFloor() {
-		direction = -1
-	}
-	a.SendMessage(direction, reply)
+	a.SendMessage(reply)
 	a.Log("I recieved an askIntendedFoodTaken message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent1) HandleRequestLeaveFood(msg messages.RequestLeaveFoodMessage) {
 	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), true)
-	direction := 1
-	if a.Floor() > msg.TargetFloor() {
-		direction = -1
-	}
-	a.SendMessage(direction, reply)
+	a.SendMessage(reply)
 	a.Log("I recieved a requestLeaveFood message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent1) HandleRequestTakeFood(msg messages.RequestTakeFoodMessage) {
 	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), true)
-	direction := 1
-	if a.Floor() > msg.TargetFloor() {
-		direction = -1
-	}
-	a.SendMessage(direction, reply)
+	a.SendMessage(reply)
 	a.Log("I recieved a requestTakeFood message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 

--- a/pkg/agents/team1/agent1/agent.go
+++ b/pkg/agents/team1/agent1/agent.go
@@ -32,37 +32,37 @@ func (a *CustomAgent1) Run() {
 	r := rand.Intn(8)
 	switch r {
 	case 0:
-		msg := messages.NewAskFoodTakenMessage(a.ID(), a.Floor(), a.Floor()+1)
-		a.SendMessage(1, msg)
-		a.Log("I sent a message", infra.Fields{"message": "AskFoodTaken"})
+		msg := messages.NewAskFoodTakenMessage(a.ID(), a.Floor(), a.Floor()-2)
+		a.SendMessage(-1, msg)
+		a.Log("I sent a message", infra.Fields{"message": "AskFoodTaken", "floor": a.Floor()})
 	case 1:
-		msg := messages.NewAskHPMessage(a.ID(), a.Floor(), a.Floor()+1)
+		msg := messages.NewAskHPMessage(a.ID(), a.Floor(), a.Floor()+3)
 		a.SendMessage(1, msg)
-		a.Log("I sent a message", infra.Fields{"message": "AskHP"})
+		a.Log("I sent a message", infra.Fields{"message": "AskHP", "floor": a.Floor()})
 	case 2:
-		msg := messages.NewAskIntendedFoodIntakeMessage(a.ID(), a.Floor(), a.Floor()+1)
+		msg := messages.NewAskIntendedFoodIntakeMessage(a.ID(), a.Floor(), a.Floor()+2)
 		a.SendMessage(1, msg)
-		a.Log("I sent a message", infra.Fields{"message": "AskIntendedFoodIntake"})
+		a.Log("I sent a message", infra.Fields{"message": "AskIntendedFoodIntake", "floor": a.Floor()})
 	case 3:
 		msg := messages.NewRequestLeaveFoodMessage(a.ID(), a.Floor(), a.Floor()+1, 10)
 		a.SendMessage(1, msg)
-		a.Log("I sent a message", infra.Fields{"message": "RequestLeaveFood"})
+		a.Log("I sent a message", infra.Fields{"message": "RequestLeaveFood", "floor": a.Floor()})
 	case 4:
-		msg := messages.NewRequestTakeFoodMessage(a.ID(), a.Floor(), a.Floor()+1, 20)
-		a.SendMessage(1, msg)
-		a.Log("I sent a message", infra.Fields{"message": "RequestTakeFood"})
+		msg := messages.NewRequestTakeFoodMessage(a.ID(), a.Floor(), a.Floor()-3, 20)
+		a.SendMessage(-1, msg)
+		a.Log("I sent a message", infra.Fields{"message": "RequestTakeFood", "floor": a.Floor()})
 	case 5:
-		msg := messages.NewStateFoodTakenMessage(a.ID(), a.Floor(), a.Floor()+1, 30)
+		msg := messages.NewStateFoodTakenMessage(a.ID(), a.Floor(), a.Floor()+2, 30)
 		a.SendMessage(1, msg)
-		a.Log("I sent a message", infra.Fields{"message": "StateFoodTaken"})
+		a.Log("I sent a message", infra.Fields{"message": "StateFoodTaken", "floor": a.Floor()})
 	case 6:
-		msg := messages.NewStateHPMessage(a.ID(), a.Floor(), a.Floor()+1, 40)
-		a.SendMessage(1, msg)
-		a.Log("I sent a message", infra.Fields{"message": "StateHP"})
+		msg := messages.NewStateHPMessage(a.ID(), a.Floor(), a.Floor()-1, 40)
+		a.SendMessage(-1, msg)
+		a.Log("I sent a message", infra.Fields{"message": "StateHP", "floor": a.Floor()})
 	case 7:
-		msg := messages.NewStateIntendedFoodIntakeMessage(a.ID(), a.Floor(), a.Floor()+1, 50)
+		msg := messages.NewStateIntendedFoodIntakeMessage(a.ID(), a.Floor(), a.Floor()+3, 50)
 		a.SendMessage(1, msg)
-		a.Log("I sent a message", infra.Fields{"message": "StateIntendedFoodIntake"})
+		a.Log("I sent a message", infra.Fields{"message": "StateIntendedFoodIntake", "floor": a.Floor()})
 	}
 	a.Log("My agent is doing something", infra.Fields{"thing": "potatoe", "another_thing": "another potatoe"})
 	_, err := a.TakeFood(16)
@@ -77,51 +77,71 @@ func (a *CustomAgent1) Run() {
 }
 
 func (a *CustomAgent1) HandleAskHP(msg messages.AskHPMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, a.HP())
-	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
-	a.Log("I recieved an askHP message from ", infra.Fields{"floor": msg.SenderFloor()})
+	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), a.HP())
+	direction := 1
+	if a.Floor() > msg.TargetFloor() {
+		direction = -1
+	}
+	a.SendMessage(direction, reply)
+	a.Log("I recieved an askHP message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent1) HandleAskFoodTaken(msg messages.AskFoodTakenMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, 10)
-	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
-	a.Log("I recieved an askFoodTaken message from ", infra.Fields{"floor": msg.SenderFloor()})
+	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), 10)
+	direction := 1
+	if a.Floor() > msg.TargetFloor() {
+		direction = -1
+	}
+	a.SendMessage(direction, reply)
+	a.Log("I recieved an askFoodTaken message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent1) HandleAskIntendedFoodTaken(msg messages.AskIntendedFoodIntakeMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, 11)
-	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
-	a.Log("I recieved an askIntendedFoodTaken message from ", infra.Fields{"floor": msg.SenderFloor()})
+	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), 11)
+	direction := 1
+	if a.Floor() > msg.TargetFloor() {
+		direction = -1
+	}
+	a.SendMessage(direction, reply)
+	a.Log("I recieved an askIntendedFoodTaken message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent1) HandleRequestLeaveFood(msg messages.RequestLeaveFoodMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, true)
-	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
-	a.Log("I recieved a requestLeaveFood message from ", infra.Fields{"floor": msg.SenderFloor()})
+	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), true)
+	direction := 1
+	if a.Floor() > msg.TargetFloor() {
+		direction = -1
+	}
+	a.SendMessage(direction, reply)
+	a.Log("I recieved a requestLeaveFood message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent1) HandleRequestTakeFood(msg messages.RequestTakeFoodMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, true)
-	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
-	a.Log("I recieved a requestTakeFood message from ", infra.Fields{"floor": msg.SenderFloor()})
+	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), true)
+	direction := 1
+	if a.Floor() > msg.TargetFloor() {
+		direction = -1
+	}
+	a.SendMessage(direction, reply)
+	a.Log("I recieved a requestTakeFood message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent1) HandleResponse(msg messages.BoolResponseMessage) {
 	response := msg.Response()
-	a.Log("I recieved a Response message from ", infra.Fields{"senderID": msg.SenderID(), "floor": msg.SenderFloor(), "response": response})
+	a.Log("I recieved a Response message from ", infra.Fields{"senderID": msg.SenderID(), "senderFloor": msg.SenderFloor(), "response": response, "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent1) HandleStateFoodTaken(msg messages.StateFoodTakenMessage) {
 	statement := msg.Statement()
-	a.Log("I recieved a StateFoodTaken message from ", infra.Fields{"floor": msg.SenderFloor(), "statement": statement})
+	a.Log("I recieved a StateFoodTaken message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "statement": statement, "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent1) HandleStateHP(msg messages.StateHPMessage) {
 	statement := msg.Statement()
-	a.Log("I recieved a StateHP message from ", infra.Fields{"floor": msg.SenderFloor(), "statement": statement})
+	a.Log("I recieved a StateHP message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "statement": statement, "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent1) HandleStateIntendedFoodTaken(msg messages.StateIntendedFoodIntakeMessage) {
 	statement := msg.Statement()
-	a.Log("I recieved a StateIntendedFoodTaken message from ", infra.Fields{"floor": msg.SenderFloor(), "statement": statement})
+	a.Log("I recieved a StateIntendedFoodTaken message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "statement": statement, "myFloor": a.Floor()})
 }

--- a/pkg/agents/team1/agent1/agent.go
+++ b/pkg/agents/team1/agent1/agent.go
@@ -32,35 +32,35 @@ func (a *CustomAgent1) Run() {
 	r := rand.Intn(8)
 	switch r {
 	case 0:
-		msg := messages.NewAskFoodTakenMessage(a.ID(), a.Floor())
+		msg := messages.NewAskFoodTakenMessage(a.ID(), a.Floor(), a.Floor()+1)
 		a.SendMessage(1, msg)
 		a.Log("I sent a message", infra.Fields{"message": "AskFoodTaken"})
 	case 1:
-		msg := messages.NewAskHPMessage(a.ID(), a.Floor())
+		msg := messages.NewAskHPMessage(a.ID(), a.Floor(), a.Floor()+1)
 		a.SendMessage(1, msg)
 		a.Log("I sent a message", infra.Fields{"message": "AskHP"})
 	case 2:
-		msg := messages.NewAskIntendedFoodIntakeMessage(a.ID(), a.Floor())
+		msg := messages.NewAskIntendedFoodIntakeMessage(a.ID(), a.Floor(), a.Floor()+1)
 		a.SendMessage(1, msg)
 		a.Log("I sent a message", infra.Fields{"message": "AskIntendedFoodIntake"})
 	case 3:
-		msg := messages.NewRequestLeaveFoodMessage(a.ID(), a.Floor(), 10)
+		msg := messages.NewRequestLeaveFoodMessage(a.ID(), a.Floor(), a.Floor()+1, 10)
 		a.SendMessage(1, msg)
 		a.Log("I sent a message", infra.Fields{"message": "RequestLeaveFood"})
 	case 4:
-		msg := messages.NewRequestTakeFoodMessage(a.ID(), a.Floor(), 20)
+		msg := messages.NewRequestTakeFoodMessage(a.ID(), a.Floor(), a.Floor()+1, 20)
 		a.SendMessage(1, msg)
 		a.Log("I sent a message", infra.Fields{"message": "RequestTakeFood"})
 	case 5:
-		msg := messages.NewStateFoodTakenMessage(a.ID(), a.Floor(), 30)
+		msg := messages.NewStateFoodTakenMessage(a.ID(), a.Floor(), a.Floor()+1, 30)
 		a.SendMessage(1, msg)
 		a.Log("I sent a message", infra.Fields{"message": "StateFoodTaken"})
 	case 6:
-		msg := messages.NewStateHPMessage(a.ID(), a.Floor(), 40)
+		msg := messages.NewStateHPMessage(a.ID(), a.Floor(), a.Floor()+1, 40)
 		a.SendMessage(1, msg)
 		a.Log("I sent a message", infra.Fields{"message": "StateHP"})
 	case 7:
-		msg := messages.NewStateIntendedFoodIntakeMessage(a.ID(), a.Floor(), 50)
+		msg := messages.NewStateIntendedFoodIntakeMessage(a.ID(), a.Floor(), a.Floor()+1, 50)
 		a.SendMessage(1, msg)
 		a.Log("I sent a message", infra.Fields{"message": "StateIntendedFoodIntake"})
 	}
@@ -77,31 +77,31 @@ func (a *CustomAgent1) Run() {
 }
 
 func (a *CustomAgent1) HandleAskHP(msg messages.AskHPMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), a.HP())
+	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, a.HP())
 	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
 	a.Log("I recieved an askHP message from ", infra.Fields{"floor": msg.SenderFloor()})
 }
 
 func (a *CustomAgent1) HandleAskFoodTaken(msg messages.AskFoodTakenMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), 10)
+	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, 10)
 	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
 	a.Log("I recieved an askFoodTaken message from ", infra.Fields{"floor": msg.SenderFloor()})
 }
 
 func (a *CustomAgent1) HandleAskIntendedFoodTaken(msg messages.AskIntendedFoodIntakeMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), 11)
+	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, 11)
 	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
 	a.Log("I recieved an askIntendedFoodTaken message from ", infra.Fields{"floor": msg.SenderFloor()})
 }
 
 func (a *CustomAgent1) HandleRequestLeaveFood(msg messages.RequestLeaveFoodMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), true)
+	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, true)
 	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
 	a.Log("I recieved a requestLeaveFood message from ", infra.Fields{"floor": msg.SenderFloor()})
 }
 
 func (a *CustomAgent1) HandleRequestTakeFood(msg messages.RequestTakeFoodMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), true)
+	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, true)
 	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
 	a.Log("I recieved a requestTakeFood message from ", infra.Fields{"floor": msg.SenderFloor()})
 }

--- a/pkg/agents/team1/agent2/agent.go
+++ b/pkg/agents/team1/agent2/agent.go
@@ -40,51 +40,31 @@ func (a *CustomAgent2) Run() {
 
 func (a *CustomAgent2) HandleAskHP(msg messages.AskHPMessage) {
 	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), a.HP())
-	direction := 1
-	if a.Floor() > msg.TargetFloor() {
-		direction = -1
-	}
-	a.SendMessage(direction, reply)
+	a.SendMessage(reply)
 	a.Log("I recieved an askHP message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent2) HandleAskFoodTaken(msg messages.AskFoodTakenMessage) {
 	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), 10)
-	direction := 1
-	if a.Floor() > msg.TargetFloor() {
-		direction = -1
-	}
-	a.SendMessage(direction, reply)
+	a.SendMessage(reply)
 	a.Log("I recieved an askFoodTaken message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent2) HandleAskIntendedFoodTaken(msg messages.AskIntendedFoodIntakeMessage) {
 	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), 11)
-	direction := 1
-	if a.Floor() > msg.TargetFloor() {
-		direction = -1
-	}
-	a.SendMessage(direction, reply)
+	a.SendMessage(reply)
 	a.Log("I recieved an askIntendedFoodTaken message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent2) HandleRequestLeaveFood(msg messages.RequestLeaveFoodMessage) {
 	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), true)
-	direction := 1
-	if a.Floor() > msg.TargetFloor() {
-		direction = -1
-	}
-	a.SendMessage(direction, reply)
+	a.SendMessage(reply)
 	a.Log("I recieved a requestLeaveFood message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent2) HandleRequestTakeFood(msg messages.RequestTakeFoodMessage) {
 	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), true)
-	direction := 1
-	if a.Floor() > msg.TargetFloor() {
-		direction = -1
-	}
-	a.SendMessage(direction, reply)
+	a.SendMessage(reply)
 	a.Log("I recieved a requestTakeFood message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 

--- a/pkg/agents/team1/agent2/agent.go
+++ b/pkg/agents/team1/agent2/agent.go
@@ -39,31 +39,31 @@ func (a *CustomAgent2) Run() {
 }
 
 func (a *CustomAgent2) HandleAskHP(msg messages.AskHPMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), a.HP())
+	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, a.HP())
 	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
 	a.Log("I recieved an askHP message from ", infra.Fields{"floor": msg.SenderFloor()})
 }
 
 func (a *CustomAgent2) HandleAskFoodTaken(msg messages.AskFoodTakenMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), 10)
+	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, 10)
 	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
 	a.Log("I recieved an askFoodTaken message from ", infra.Fields{"floor": msg.SenderFloor()})
 }
 
 func (a *CustomAgent2) HandleAskIntendedFoodTaken(msg messages.AskIntendedFoodIntakeMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), 11)
+	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, 11)
 	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
 	a.Log("I recieved an askIntendedFoodTaken message from ", infra.Fields{"floor": msg.SenderFloor()})
 }
 
 func (a *CustomAgent2) HandleRequestLeaveFood(msg messages.RequestLeaveFoodMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), true)
+	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, true)
 	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
 	a.Log("I recieved a requestLeaveFood message from ", infra.Fields{"floor": msg.SenderFloor()})
 }
 
 func (a *CustomAgent2) HandleRequestTakeFood(msg messages.RequestTakeFoodMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), true)
+	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, true)
 	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
 	a.Log("I recieved a requestTakeFood message from ", infra.Fields{"floor": msg.SenderFloor()})
 }

--- a/pkg/agents/team1/agent2/agent.go
+++ b/pkg/agents/team1/agent2/agent.go
@@ -39,33 +39,53 @@ func (a *CustomAgent2) Run() {
 }
 
 func (a *CustomAgent2) HandleAskHP(msg messages.AskHPMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, a.HP())
-	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
-	a.Log("I recieved an askHP message from ", infra.Fields{"floor": msg.SenderFloor()})
+	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), a.HP())
+	direction := 1
+	if a.Floor() > msg.TargetFloor() {
+		direction = -1
+	}
+	a.SendMessage(direction, reply)
+	a.Log("I recieved an askHP message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent2) HandleAskFoodTaken(msg messages.AskFoodTakenMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, 10)
-	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
-	a.Log("I recieved an askFoodTaken message from ", infra.Fields{"floor": msg.SenderFloor()})
+	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), 10)
+	direction := 1
+	if a.Floor() > msg.TargetFloor() {
+		direction = -1
+	}
+	a.SendMessage(direction, reply)
+	a.Log("I recieved an askFoodTaken message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent2) HandleAskIntendedFoodTaken(msg messages.AskIntendedFoodIntakeMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, 11)
-	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
-	a.Log("I recieved an askIntendedFoodTaken message from ", infra.Fields{"floor": msg.SenderFloor()})
+	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), 11)
+	direction := 1
+	if a.Floor() > msg.TargetFloor() {
+		direction = -1
+	}
+	a.SendMessage(direction, reply)
+	a.Log("I recieved an askIntendedFoodTaken message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent2) HandleRequestLeaveFood(msg messages.RequestLeaveFoodMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, true)
-	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
-	a.Log("I recieved a requestLeaveFood message from ", infra.Fields{"floor": msg.SenderFloor()})
+	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), true)
+	direction := 1
+	if a.Floor() > msg.TargetFloor() {
+		direction = -1
+	}
+	a.SendMessage(direction, reply)
+	a.Log("I recieved a requestLeaveFood message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent2) HandleRequestTakeFood(msg messages.RequestTakeFoodMessage) {
-	reply := msg.Reply(a.ID(), a.Floor(), a.Floor()-1, true)
-	a.SendMessage(msg.SenderFloor()-a.Floor(), reply)
-	a.Log("I recieved a requestTakeFood message from ", infra.Fields{"floor": msg.SenderFloor()})
+	reply := msg.Reply(a.ID(), a.Floor(), msg.SenderFloor(), true)
+	direction := 1
+	if a.Floor() > msg.TargetFloor() {
+		direction = -1
+	}
+	a.SendMessage(direction, reply)
+	a.Log("I recieved a requestTakeFood message from ", infra.Fields{"senderFloor": msg.SenderFloor(), "myFloor": a.Floor()})
 }
 
 func (a *CustomAgent2) HandleResponse(msg messages.BoolResponseMessage) {

--- a/pkg/agents/team6/config.go
+++ b/pkg/agents/team6/config.go
@@ -106,7 +106,7 @@ func (a *CustomAgent6) Run() {
 	a.Log("Team 6 agent has HP:", infra.Fields{"hp": a.HP()})
 
 	msg := messages.NewAskHPMessage(a.ID(), a.Floor(), a.Floor()+1)
-	a.SendMessage(1, msg)
+	a.SendMessage(msg)
 	a.Log("Team 6 sent message:", infra.Fields{"floor": a.Floor(), "messageType": msg.MessageType().String()})
 
 }

--- a/pkg/agents/team6/config.go
+++ b/pkg/agents/team6/config.go
@@ -105,7 +105,7 @@ func (a *CustomAgent6) Run() {
 	a.Log("Team 6 took:", infra.Fields{"foodTaken": foodAmount, "bType": a.currBehaviour.String()})
 	a.Log("Team 6 agent has HP:", infra.Fields{"hp": a.HP()})
 
-	msg := messages.NewAskHPMessage(a.ID(), a.Floor())
+	msg := messages.NewAskHPMessage(a.ID(), a.Floor(), a.Floor()+1)
 	a.SendMessage(1, msg)
 	a.Log("Team 6 sent message:", infra.Fields{"floor": a.Floor(), "messageType": msg.MessageType().String()})
 

--- a/pkg/infra/baseagent.go
+++ b/pkg/infra/baseagent.go
@@ -241,6 +241,5 @@ func (a *Base) HandlePropogate(msg messages.Message) {
 	if a.Floor() > msg.TargetFloor() {
 		direction = -1
 	}
-	a.Log("Propogating", Fields{"floor": a.floor})
 	a.SendMessage(direction, msg)
 }

--- a/pkg/infra/baseagent.go
+++ b/pkg/infra/baseagent.go
@@ -31,6 +31,7 @@ type Agent interface {
 	HandleStateIntendedFoodTaken(msg messages.StateIntendedFoodIntakeMessage)
 	HandleProposeTreaty(msg messages.ProposeTreatyMessage)
 	HandleTreatyResponse(msg messages.TreatyResponseMessage)
+	HandlePropogate(msg messages.Message)
 }
 
 type Fields = log.Fields

--- a/pkg/infra/baseagent.go
+++ b/pkg/infra/baseagent.go
@@ -19,6 +19,7 @@ import (
 type Agent interface {
 	Run()
 	IsAlive() bool
+	Floor() int
 	BaseAgent() *Base
 	HandleAskHP(msg messages.AskHPMessage)
 	HandleAskFoodTaken(msg messages.AskFoodTakenMessage)
@@ -234,3 +235,12 @@ func (a *Base) HandleStateHP(msg messages.StateHPMessage)                       
 func (a *Base) HandleStateIntendedFoodTaken(msg messages.StateIntendedFoodIntakeMessage) {}
 func (a *Base) HandleProposeTreaty(msg messages.ProposeTreatyMessage)                    {}
 func (a *Base) HandleTreatyResponse(msg messages.TreatyResponseMessage)                  {}
+
+func (a *Base) HandlePropogate(msg messages.Message) {
+	direction := 1
+	if a.Floor() > msg.TargetFloor() {
+		direction = -1
+	}
+	a.Log("Propogating", Fields{"floor": a.floor})
+	a.SendMessage(direction, msg)
+}

--- a/pkg/infra/baseagent.go
+++ b/pkg/infra/baseagent.go
@@ -214,10 +214,8 @@ func (a *Base) ReceiveMessage() messages.Message {
 	}
 }
 
-func (a *Base) SendMessage(direction int, msg messages.Message) {
-	if (direction == -1) || (direction == 1) {
-		a.tower.SendMessage(direction, a.floor, msg)
-	}
+func (a *Base) SendMessage(msg messages.Message) {
+	a.tower.SendMessage(a.floor, msg)
 }
 
 func (a *Base) HealthInfo() *health.HealthInfo {
@@ -237,9 +235,5 @@ func (a *Base) HandleProposeTreaty(msg messages.ProposeTreatyMessage)           
 func (a *Base) HandleTreatyResponse(msg messages.TreatyResponseMessage)                  {}
 
 func (a *Base) HandlePropogate(msg messages.Message) {
-	direction := 1
-	if a.Floor() > msg.TargetFloor() {
-		direction = -1
-	}
-	a.SendMessage(direction, msg)
+	a.SendMessage(msg)
 }

--- a/pkg/infra/tower.go
+++ b/pkg/infra/tower.go
@@ -104,7 +104,11 @@ func (t *Tower) endOfDay() {
 	}
 }
 
-func (t *Tower) SendMessage(direction int, senderFloor int, msg messages.Message) {
+func (t *Tower) SendMessage(senderFloor int, msg messages.Message) {
+	direction := 1
+	if msg.SenderFloor() > msg.TargetFloor() {
+		direction = -1
+	}
 	for _, agent := range t.Agents {
 		agent := agent.BaseAgent()
 		if agent.floor == senderFloor+direction {

--- a/pkg/messages/askFoodTakenMessage.go
+++ b/pkg/messages/askFoodTakenMessage.go
@@ -6,15 +6,15 @@ type AskFoodTakenMessage struct {
 	*BaseMessage
 }
 
-func NewAskFoodTakenMessage(senderID uuid.UUID, senderFloor int) *AskFoodTakenMessage {
+func NewAskFoodTakenMessage(senderID uuid.UUID, senderFloor int, targetFloor int) *AskFoodTakenMessage {
 	msg := &AskFoodTakenMessage{
-		NewBaseMessage(senderID, senderFloor, AskFoodTaken),
+		NewBaseMessage(senderID, senderFloor, targetFloor, AskFoodTaken),
 	}
 	return msg
 }
 
-func (msg *AskFoodTakenMessage) Reply(senderID uuid.UUID, senderFloor int, food int) StateMessage {
-	reply := NewStateFoodTakenMessage(senderID, senderFloor, food)
+func (msg *AskFoodTakenMessage) Reply(senderID uuid.UUID, senderFloor int, targetFloor int, food int) StateMessage {
+	reply := NewStateFoodTakenMessage(senderID, senderFloor, targetFloor, food)
 	return reply
 }
 

--- a/pkg/messages/askFoodTakenMessage.go
+++ b/pkg/messages/askFoodTakenMessage.go
@@ -19,5 +19,9 @@ func (msg *AskFoodTakenMessage) Reply(senderID uuid.UUID, senderFloor int, targe
 }
 
 func (msg *AskFoodTakenMessage) Visit(a Agent) {
-	a.HandleAskFoodTaken(*msg)
+	if msg.TargetFloor() != a.Floor() {
+		a.HandlePropogate(msg)
+	} else {
+		a.HandleAskFoodTaken(*msg)
+	}
 }

--- a/pkg/messages/askHPMessage.go
+++ b/pkg/messages/askHPMessage.go
@@ -6,15 +6,15 @@ type AskHPMessage struct {
 	*BaseMessage
 }
 
-func NewAskHPMessage(senderID uuid.UUID, senderFloor int) *AskHPMessage {
+func NewAskHPMessage(senderID uuid.UUID, senderFloor int, targetFloor int) *AskHPMessage {
 	msg := &AskHPMessage{
-		NewBaseMessage(senderID, senderFloor, AskHP),
+		NewBaseMessage(senderID, senderFloor, targetFloor, AskHP),
 	}
 	return msg
 }
 
-func (msg *AskHPMessage) Reply(senderID uuid.UUID, senderFloor int, hp int) StateMessage {
-	reply := NewStateHPMessage(senderID, senderFloor, hp)
+func (msg *AskHPMessage) Reply(senderID uuid.UUID, senderFloor int, targetFloor int, hp int) StateMessage {
+	reply := NewStateHPMessage(senderID, senderFloor, targetFloor, hp)
 	return reply
 }
 

--- a/pkg/messages/askHPMessage.go
+++ b/pkg/messages/askHPMessage.go
@@ -19,5 +19,9 @@ func (msg *AskHPMessage) Reply(senderID uuid.UUID, senderFloor int, targetFloor 
 }
 
 func (msg *AskHPMessage) Visit(a Agent) {
-	a.HandleAskHP(*msg)
+	if msg.TargetFloor() != a.Floor() {
+		a.HandlePropogate(msg)
+	} else {
+		a.HandleAskHP(*msg)
+	}
 }

--- a/pkg/messages/askIntendedFoodIntakeMessage.go
+++ b/pkg/messages/askIntendedFoodIntakeMessage.go
@@ -19,5 +19,9 @@ func (msg *AskIntendedFoodIntakeMessage) Reply(senderID uuid.UUID, senderFloor i
 }
 
 func (msg *AskIntendedFoodIntakeMessage) Visit(a Agent) {
-	a.HandleAskIntendedFoodTaken(*msg)
+	if msg.TargetFloor() != a.Floor() {
+		a.HandlePropogate(msg)
+	} else {
+		a.HandleAskIntendedFoodTaken(*msg)
+	}
 }

--- a/pkg/messages/askIntendedFoodIntakeMessage.go
+++ b/pkg/messages/askIntendedFoodIntakeMessage.go
@@ -6,15 +6,15 @@ type AskIntendedFoodIntakeMessage struct {
 	*BaseMessage
 }
 
-func NewAskIntendedFoodIntakeMessage(senderID uuid.UUID, senderFloor int) *AskIntendedFoodIntakeMessage {
+func NewAskIntendedFoodIntakeMessage(senderID uuid.UUID, senderFloor int, targetFloor int) *AskIntendedFoodIntakeMessage {
 	msg := &AskIntendedFoodIntakeMessage{
-		NewBaseMessage(senderID, senderFloor, AskIntendedFoodIntake),
+		NewBaseMessage(senderID, senderFloor, targetFloor, AskIntendedFoodIntake),
 	}
 	return msg
 }
 
-func (msg *AskIntendedFoodIntakeMessage) Reply(senderID uuid.UUID, senderFloor int, food int) StateMessage {
-	reply := NewStateIntendedFoodIntakeMessage(senderID, senderFloor, food)
+func (msg *AskIntendedFoodIntakeMessage) Reply(senderID uuid.UUID, senderFloor int, targetFloor int, food int) StateMessage {
+	reply := NewStateIntendedFoodIntakeMessage(senderID, senderFloor, targetFloor, food)
 	return reply
 }
 

--- a/pkg/messages/baseMessage.go
+++ b/pkg/messages/baseMessage.go
@@ -27,6 +27,7 @@ const (
 )
 
 type Agent interface {
+	Floor() int
 	HandleAskHP(msg AskHPMessage)
 	HandleAskFoodTaken(msg AskFoodTakenMessage)
 	HandleAskIntendedFoodTaken(msg AskIntendedFoodIntakeMessage)
@@ -38,11 +39,13 @@ type Agent interface {
 	HandleStateIntendedFoodTaken(msg StateIntendedFoodIntakeMessage)
 	HandleProposeTreaty(msg ProposeTreatyMessage)
 	HandleTreatyResponse(msg TreatyResponseMessage)
+	HandlePropogate(msg Message)
 }
 
 type Message interface {
 	MessageType() MessageType
 	SenderFloor() int
+	TargetFloor() int
 	ID() uuid.UUID
 	Visit(a Agent)
 }
@@ -94,17 +97,21 @@ func NewBaseMessage(senderID uuid.UUID, senderFloor int, targetFloor int, messag
 	return msg
 }
 
-func (msg BaseMessage) MessageType() MessageType {
+func (msg *BaseMessage) MessageType() MessageType {
 	return msg.messageType
 }
 
-func (msg BaseMessage) SenderFloor() int {
+func (msg *BaseMessage) SenderFloor() int {
 	return msg.senderFloor
 }
 
-func (msg BaseMessage) ID() uuid.UUID {
+func (msg *BaseMessage) TargetFloor() int {
+	return msg.targetFloor
+}
+
+func (msg *BaseMessage) ID() uuid.UUID {
 	return msg.id
 }
-func (msg BaseMessage) SenderID() uuid.UUID {
+func (msg *BaseMessage) SenderID() uuid.UUID {
 	return msg.senderID
 }

--- a/pkg/messages/baseMessage.go
+++ b/pkg/messages/baseMessage.go
@@ -78,14 +78,16 @@ type ResponseMessage interface {
 type BaseMessage struct {
 	senderID    uuid.UUID
 	senderFloor int
+	targetFloor int
 	messageType MessageType
 	id          uuid.UUID
 }
 
-func NewBaseMessage(senderID uuid.UUID, senderFloor int, messageType MessageType) *BaseMessage {
+func NewBaseMessage(senderID uuid.UUID, senderFloor int, targetFloor int, messageType MessageType) *BaseMessage {
 	msg := &BaseMessage{
 		senderID:    senderID,
 		senderFloor: senderFloor,
+		targetFloor: targetFloor,
 		messageType: messageType,
 		id:          uuid.New(),
 	}

--- a/pkg/messages/proposeTreatyMessage.go
+++ b/pkg/messages/proposeTreatyMessage.go
@@ -7,9 +7,9 @@ type ProposeTreatyMessage struct {
 	treaty Treaty
 }
 
-func NewProposalMessage(senderID uuid.UUID, senderFloor int, treaty Treaty) *ProposeTreatyMessage {
+func NewProposalMessage(senderID uuid.UUID, senderFloor int, targetFloor int, treaty Treaty) *ProposeTreatyMessage {
 	msg := &ProposeTreatyMessage{
-		NewBaseMessage(senderID, senderFloor, ProposeTreaty),
+		NewBaseMessage(senderID, senderFloor, targetFloor, ProposeTreaty),
 		treaty,
 	}
 	return msg
@@ -23,7 +23,7 @@ func (msg *ProposeTreatyMessage) Visit(a Agent) {
 	a.HandleProposeTreaty(*msg)
 }
 
-func (msg *ProposeTreatyMessage) Reply(senderID uuid.UUID, senderFloor int, response bool) TreatyResponseMessage {
-	reply := *NewTreatyResponseMessage(senderID, senderFloor, response, msg.treaty.Id(), msg.ID())
+func (msg *ProposeTreatyMessage) Reply(senderID uuid.UUID, senderFloor int, targetFloor int, response bool) TreatyResponseMessage {
+	reply := *NewTreatyResponseMessage(senderID, senderFloor, targetFloor, response, msg.treaty.Id(), msg.ID())
 	return reply
 }

--- a/pkg/messages/proposeTreatyMessage.go
+++ b/pkg/messages/proposeTreatyMessage.go
@@ -20,7 +20,11 @@ func (msg *ProposeTreatyMessage) Treaty() Treaty {
 }
 
 func (msg *ProposeTreatyMessage) Visit(a Agent) {
-	a.HandleProposeTreaty(*msg)
+	if msg.TargetFloor() != a.Floor() {
+		a.HandlePropogate(msg)
+	} else {
+		a.HandleProposeTreaty(*msg)
+	}
 }
 
 func (msg *ProposeTreatyMessage) Reply(senderID uuid.UUID, senderFloor int, targetFloor int, response bool) TreatyResponseMessage {

--- a/pkg/messages/requestLeaveFoodMessage.go
+++ b/pkg/messages/requestLeaveFoodMessage.go
@@ -25,5 +25,9 @@ func (msg *RequestLeaveFoodMessage) Reply(senderID uuid.UUID, senderFloor int, t
 }
 
 func (msg *RequestLeaveFoodMessage) Visit(a Agent) {
-	a.HandleRequestLeaveFood(*msg)
+	if msg.TargetFloor() != a.Floor() {
+		a.HandlePropogate(msg)
+	} else {
+		a.HandleRequestLeaveFood(*msg)
+	}
 }

--- a/pkg/messages/requestLeaveFoodMessage.go
+++ b/pkg/messages/requestLeaveFoodMessage.go
@@ -7,9 +7,9 @@ type RequestLeaveFoodMessage struct {
 	food int
 }
 
-func NewRequestLeaveFoodMessage(senderID uuid.UUID, senderFloor int, food int) *RequestLeaveFoodMessage {
+func NewRequestLeaveFoodMessage(senderID uuid.UUID, senderFloor int, targetFloor int, food int) *RequestLeaveFoodMessage {
 	msg := &RequestLeaveFoodMessage{
-		NewBaseMessage(senderID, senderFloor, RequestLeaveFood),
+		NewBaseMessage(senderID, senderFloor, targetFloor, RequestLeaveFood),
 		food,
 	}
 	return msg
@@ -19,8 +19,8 @@ func (msg *RequestLeaveFoodMessage) Request() int {
 	return msg.food
 }
 
-func (msg *RequestLeaveFoodMessage) Reply(senderID uuid.UUID, senderFloor int, response bool) ResponseMessage {
-	reply := NewResponseMessage(senderID, senderFloor, response, msg.ID())
+func (msg *RequestLeaveFoodMessage) Reply(senderID uuid.UUID, senderFloor int, targetFloor int, response bool) ResponseMessage {
+	reply := NewResponseMessage(senderID, senderFloor, targetFloor, response, msg.ID())
 	return reply
 }
 

--- a/pkg/messages/requestTakeFoodMessage.go
+++ b/pkg/messages/requestTakeFoodMessage.go
@@ -26,5 +26,9 @@ func (msg *RequestTakeFoodMessage) Reply(senderID uuid.UUID, senderFloor int, ta
 }
 
 func (msg *RequestTakeFoodMessage) Visit(a Agent) {
-	a.HandleRequestTakeFood(*msg)
+	if msg.TargetFloor() != a.Floor() {
+		a.HandlePropogate(msg)
+	} else {
+		a.HandleRequestTakeFood(*msg)
+	}
 }

--- a/pkg/messages/requestTakeFoodMessage.go
+++ b/pkg/messages/requestTakeFoodMessage.go
@@ -7,9 +7,9 @@ type RequestTakeFoodMessage struct {
 	food int
 }
 
-func NewRequestTakeFoodMessage(senderID uuid.UUID, senderFloor int, food int) *RequestTakeFoodMessage {
+func NewRequestTakeFoodMessage(senderID uuid.UUID, senderFloor int, targetFloor int, food int) *RequestTakeFoodMessage {
 	msg := &RequestTakeFoodMessage{
-		NewBaseMessage(senderID, senderFloor, RequestTakeFood),
+		NewBaseMessage(senderID, senderFloor, targetFloor, RequestTakeFood),
 		food,
 	}
 	return msg
@@ -20,8 +20,8 @@ func (msg *RequestTakeFoodMessage) Request() int {
 
 }
 
-func (msg *RequestTakeFoodMessage) Reply(senderID uuid.UUID, senderFloor int, response bool) ResponseMessage {
-	reply := NewResponseMessage(senderID, senderFloor, response, msg.ID())
+func (msg *RequestTakeFoodMessage) Reply(senderID uuid.UUID, senderFloor int, targetFloor int, response bool) ResponseMessage {
+	reply := NewResponseMessage(senderID, senderFloor, targetFloor, response, msg.ID())
 	return reply
 }
 

--- a/pkg/messages/responseMessage.go
+++ b/pkg/messages/responseMessage.go
@@ -26,5 +26,9 @@ func (msg *BoolResponseMessage) RequestID() uuid.UUID {
 }
 
 func (msg *BoolResponseMessage) Visit(a Agent) {
-	a.HandleResponse(*msg)
+	if msg.TargetFloor() != a.Floor() {
+		a.HandlePropogate(msg)
+	} else {
+		a.HandleResponse(*msg)
+	}
 }

--- a/pkg/messages/responseMessage.go
+++ b/pkg/messages/responseMessage.go
@@ -8,9 +8,9 @@ type BoolResponseMessage struct {
 	requestId uuid.UUID
 }
 
-func NewResponseMessage(senderID uuid.UUID, senderFloor int, response bool, requestID uuid.UUID) *BoolResponseMessage {
+func NewResponseMessage(senderID uuid.UUID, senderFloor int, targetFloor int, response bool, requestID uuid.UUID) *BoolResponseMessage {
 	msg := &BoolResponseMessage{
-		NewBaseMessage(senderID, senderFloor, Response),
+		NewBaseMessage(senderID, senderFloor, targetFloor, Response),
 		response,
 		requestID,
 	}

--- a/pkg/messages/stateFoodTakenMessage.go
+++ b/pkg/messages/stateFoodTakenMessage.go
@@ -20,5 +20,9 @@ func (msg *StateFoodTakenMessage) Statement() int {
 }
 
 func (msg *StateFoodTakenMessage) Visit(a Agent) {
-	a.HandleStateFoodTaken(*msg)
+	if msg.TargetFloor() != a.Floor() {
+		a.HandlePropogate(msg)
+	} else {
+		a.HandleStateFoodTaken(*msg)
+	}
 }

--- a/pkg/messages/stateFoodTakenMessage.go
+++ b/pkg/messages/stateFoodTakenMessage.go
@@ -7,9 +7,9 @@ type StateFoodTakenMessage struct {
 	food int
 }
 
-func NewStateFoodTakenMessage(senderID uuid.UUID, senderFloor int, foodTaken int) *StateFoodTakenMessage {
+func NewStateFoodTakenMessage(senderID uuid.UUID, senderFloor int, targetFloor int, foodTaken int) *StateFoodTakenMessage {
 	msg := &StateFoodTakenMessage{
-		NewBaseMessage(senderID, senderFloor, StateFoodTaken),
+		NewBaseMessage(senderID, senderFloor, targetFloor, StateFoodTaken),
 		foodTaken,
 	}
 	return msg

--- a/pkg/messages/stateHPMessage.go
+++ b/pkg/messages/stateHPMessage.go
@@ -7,9 +7,9 @@ type StateHPMessage struct {
 	hp int
 }
 
-func NewStateHPMessage(senderID uuid.UUID, senderFloor int, hp int) *StateHPMessage {
+func NewStateHPMessage(senderID uuid.UUID, senderFloor int, targetFloor int, hp int) *StateHPMessage {
 	msg := &StateHPMessage{
-		NewBaseMessage(senderID, senderFloor, StateHP),
+		NewBaseMessage(senderID, senderFloor, targetFloor, StateHP),
 		hp,
 	}
 	return msg

--- a/pkg/messages/stateHPMessage.go
+++ b/pkg/messages/stateHPMessage.go
@@ -20,5 +20,9 @@ func (msg *StateHPMessage) Statement() int {
 }
 
 func (msg *StateHPMessage) Visit(a Agent) {
-	a.HandleStateHP(*msg)
+	if msg.TargetFloor() != a.Floor() {
+		a.HandlePropogate(msg)
+	} else {
+		a.HandleStateHP(*msg)
+	}
 }

--- a/pkg/messages/stateIntendedFoodIntakeMessage.go
+++ b/pkg/messages/stateIntendedFoodIntakeMessage.go
@@ -7,9 +7,9 @@ type StateIntendedFoodIntakeMessage struct {
 	intendedFood int
 }
 
-func NewStateIntendedFoodIntakeMessage(senderID uuid.UUID, senderFloor int, intendedFood int) *StateIntendedFoodIntakeMessage {
+func NewStateIntendedFoodIntakeMessage(senderID uuid.UUID, senderFloor int, targetFloor int, intendedFood int) *StateIntendedFoodIntakeMessage {
 	msg := &StateIntendedFoodIntakeMessage{
-		NewBaseMessage(senderID, senderFloor, StateIntendedFoodIntake),
+		NewBaseMessage(senderID, senderFloor, targetFloor, StateIntendedFoodIntake),
 		intendedFood,
 	}
 	return msg

--- a/pkg/messages/stateIntendedFoodIntakeMessage.go
+++ b/pkg/messages/stateIntendedFoodIntakeMessage.go
@@ -20,5 +20,9 @@ func (msg *StateIntendedFoodIntakeMessage) Statement() int {
 }
 
 func (msg *StateIntendedFoodIntakeMessage) Visit(a Agent) {
-	a.HandleStateIntendedFoodTaken(*msg)
+	if msg.TargetFloor() != a.Floor() {
+		a.HandlePropogate(msg)
+	} else {
+		a.HandleStateIntendedFoodTaken(*msg)
+	}
 }

--- a/pkg/messages/treatyResponseMessage.go
+++ b/pkg/messages/treatyResponseMessage.go
@@ -9,9 +9,9 @@ type TreatyResponseMessage struct {
 	requestID uuid.UUID
 }
 
-func NewTreatyResponseMessage(senderID uuid.UUID, senderFloor int, response bool, treatyID uuid.UUID, requestID uuid.UUID) *TreatyResponseMessage {
+func NewTreatyResponseMessage(senderID uuid.UUID, senderFloor int, targetFloor int, response bool, treatyID uuid.UUID, requestID uuid.UUID) *TreatyResponseMessage {
 	msg := &TreatyResponseMessage{
-		NewBaseMessage(senderID, senderFloor, TreatyResponse),
+		NewBaseMessage(senderID, senderFloor, targetFloor, TreatyResponse),
 		response,
 		treatyID,
 		requestID,

--- a/pkg/messages/treatyResponseMessage.go
+++ b/pkg/messages/treatyResponseMessage.go
@@ -32,5 +32,9 @@ func (msg *TreatyResponseMessage) TreatyID() uuid.UUID {
 }
 
 func (msg *TreatyResponseMessage) Visit(a Agent) {
-	a.HandleTreatyResponse(*msg)
+	if msg.TargetFloor() != a.Floor() {
+		a.HandlePropogate(msg)
+	} else {
+		a.HandleTreatyResponse(*msg)
+	}
 }


### PR DESCRIPTION
To talk to agents that are several floors away from you, the messages need to "propagate" in the correct direction.
When sending a message now please additionally specify the target floor e.g. for `AskFoodTakenMessage`s
`NewAskFoodTakenMessage(senderID uuid.UUID, senderFloor int, targetFloor int)`
Now in the `Visit` function, if the message's target floor is not equal to the agent's current floor, the agent's `HandlePropogate()` function will be called.

Of course, agents _should_ have the ability to lie, break the chain of communication or distort the message if they wanted to. However, in the "honest" iterations we assumed cooperation which meant:
- An agent does not tamper with the message as it relayed it forward
- An agent relays the message in the correct direction
- The agent does not store any information regarding a message that was not intended for him

`BaseAgent` has implemented an honest, cooperative `HandlePropogate()` function which politely sends a message in the correct direction. We ask that agent teams do not override this function in honest runs but you are welcome to override for other experiments.

(Team 6's (@MattScottEEE) message passing was slightly affected, I just added `a.Floor()+1` as a targetFloor field for one of your messages)