### PR TITLE
logging days lived by an agent

### DIFF
--- a/pkg/infra/baseagent.go
+++ b/pkg/infra/baseagent.go
@@ -165,7 +165,7 @@ func (a *Base) hpDecay(healthInfo *health.HealthInfo) {
 	}
 	a.setHasEaten(false)
 	if a.daysAtCritical >= healthInfo.MaxDayCritical {
-		a.Log("Killing agent")
+		a.Log("Killing agent", Fields{"daysLived": a.Age()})
 		newHP = 0
 	}
 	a.Log("Setting hp to " + fmt.Sprint(newHP))


### PR DESCRIPTION
# Summary
Added a field to the logs which displays the number of days lived by an agent when it is killed

Closing #196 