### PR TITLE
Cleaned up console prints

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -93,9 +92,6 @@ func main() {
 				http.Error(w, "Unable to open logs folder. There might not be any logs created yet", http.StatusInternalServerError)
 				return
 			}
-			for _, f := range files {
-				fmt.Println(f.Name())
-			}
 
 			//put them all in a struct
 			var response config.DirectoryResponse
@@ -149,11 +145,11 @@ func main() {
 			log.Fatal(err)
 		}
 	} else {
-		fmt.Println("Loading parameters...")
+		log.Info("Loading parameters...")
 
 		parameters, err := config.LoadParamFromJson(*configPathPtr)
 		if err != nil {
-			fmt.Println(err)
+			log.Error(err)
 			return
 		}
 
@@ -168,9 +164,9 @@ func main() {
 		// Listen on our channel AND a timeout channel - which ever happens first.
 		select {
 		case <-c1:
-			fmt.Println("Simulation Finished Successfully")
+			log.Info("Simulation Finished Successfully")
 		case <-time.After(time.Duration(parameters.SimTimeoutSeconds) * time.Second):
-			fmt.Println("Simulation Timeout")
+			log.Info("Simulation Timeout")
 			log.Fatal("Simulation Timeout")
 		}
 	}
@@ -196,7 +192,7 @@ func setupLogFile(parameterLogFileName string, saveMainLog bool) (ffolderName st
 	if _, err := os.Stat("logs"); os.IsNotExist(err) {
 		err := os.Mkdir("logs", 0755)
 		if err != nil {
-			fmt.Println("failed to create logs directory: ", err)
+			log.Error("failed to create logs directory: ", err)
 			return "", err
 		}
 	}
@@ -212,7 +208,7 @@ func setupLogFile(parameterLogFileName string, saveMainLog bool) (ffolderName st
 	if _, err := os.Stat(logFolderName); os.IsNotExist(err) {
 		err := os.Mkdir(logFolderName, 0755)
 		if err != nil {
-			fmt.Println("failed to create custom folder directory: ", err)
+			log.Error("failed to create custom folder directory: ", err)
 			return "", err
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -166,7 +166,6 @@ func main() {
 		case <-c1:
 			log.Info("Simulation Finished Successfully")
 		case <-time.After(time.Duration(parameters.SimTimeoutSeconds) * time.Second):
-			log.Info("Simulation Timeout")
 			log.Fatal("Simulation Timeout")
 		}
 	}

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -40,7 +40,7 @@ type ConfigParameters struct {
 	MaxDayCritical       int           `json:"maxDayCritical"`
 	HPLossBase           int           `json:"HPLossBase"`
 	HPLossSlope          float64       `json:"HPLossSlope"`
-	LogFileName          string        `json:"LogFileName"`
+	LogFolderName        string        `json:"LogFileName"`
 	LogMain              bool          `json:"LogMain"`
 	SimTimeoutSeconds    int           `json:"SimTimeoutSeconds"`
 	NumOfAgents          map[agent.AgentType]int
@@ -50,7 +50,7 @@ type ConfigParameters struct {
 }
 
 type SimulateResponse struct { // used for HTTP response on /simulate
-	LogFileName string `json:"LogFileName"`
+	LogFolderName string `json:"LogFileName"`
 }
 
 type DirectoryResponse struct { // used for HTTP response on /directory

--- a/pkg/simulation/simulation.go
+++ b/pkg/simulation/simulation.go
@@ -39,7 +39,7 @@ type SimEnv struct {
 }
 
 func NewSimEnv(parameters *config.ConfigParameters, healthInfo *health.HealthInfo) *SimEnv {
-	stateLog := logging.NewLogState(parameters.LogFileName, parameters.LogMain)
+	stateLog := logging.NewLogState(parameters.LogFolderName, parameters.LogMain)
 	return &SimEnv{
 		FoodOnPlatform: parameters.FoodOnPlatform,
 		AgentCount:     parameters.NumOfAgents,


### PR DESCRIPTION
Closes #189. 

Removed some unnecessary prints related to directories. They were left from a template i used. Oops.

Also cleaned up the console prints by using log.Info and log.Error instead of fmt.Println 

Edit: Also renamed logFileName to LogFolderName everywhere except in the json parsing, so it is still compatible with the current frontend, and also now the directory array is initialised to empty instead of nil (as per Jaafar's request)

