### PR TITLE
Timeouts now end the goroutines rather than keeping them running until the end

### DIFF
--- a/pkg/simulation/simIteration.go
+++ b/pkg/simulation/simIteration.go
@@ -1,6 +1,7 @@
 package simulation
 
 import (
+	"context"
 	"sync"
 
 	"github.com/SOMAS2021/SOMAS2021/pkg/infra"
@@ -18,7 +19,7 @@ func (sE *SimEnv) World() world.World {
 	return sE.world
 }
 
-func (sE *SimEnv) simulationLoop(t *infra.Tower) {
+func (sE *SimEnv) simulationLoop(t *infra.Tower, ctx context.Context, ch chan<- string) {
 	t.Reshuffle()
 	for sE.dayInfo.CurrTick <= sE.dayInfo.TotalTicks {
 		sE.Log("", Fields{"Current Simulation Tick": sE.dayInfo.CurrTick})
@@ -28,7 +29,16 @@ func (sE *SimEnv) simulationLoop(t *infra.Tower) {
 		sE.replaceAgents(t)
 		// t.TowerStateLog(" end of tick")
 		sE.dayInfo.CurrTick++
+
+		//returns if there is a timeout
+		//continously checks every tick since there is no way to kill a goroutine
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 	}
+	ch <- "Simulation Finished"
 }
 
 func (sE *SimEnv) TowerTick() {

--- a/pkg/simulation/simulation.go
+++ b/pkg/simulation/simulation.go
@@ -1,6 +1,8 @@
 package simulation
 
 import (
+	"context"
+
 	"github.com/SOMAS2021/SOMAS2021/pkg/agents/randomAgent"
 	"github.com/SOMAS2021/SOMAS2021/pkg/agents/team1/agent1"
 	"github.com/SOMAS2021/SOMAS2021/pkg/agents/team1/agent2"
@@ -63,7 +65,7 @@ func NewSimEnv(parameters *config.ConfigParameters, healthInfo *health.HealthInf
 	}
 }
 
-func (sE *SimEnv) Simulate() {
+func (sE *SimEnv) Simulate(ctx context.Context, ch chan<- string) {
 	sE.Log("Simulation Initializing")
 
 	totalAgents := utilFunctions.Sum(sE.AgentCount)
@@ -73,7 +75,15 @@ func (sE *SimEnv) Simulate() {
 	sE.generateInitialAgents(t)
 
 	sE.Log("Simulation Started")
-	sE.simulationLoop(t)
+	sE.simulationLoop(t, ctx, ch)
+
+	//returns if there was a timeout
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
 	sE.Log("Simulation Ended")
 	sE.Log("Summary of dead agents", infra.Fields{"Agent Type and number that died": t.DeadAgents()})
 


### PR DESCRIPTION
So up until now, when a timeout happened, main would show that there was a timeout, but the goroutine would actually keep running in the background until it was complete, wasting resources.

It turns out there is no built in way to kill a thread / goroutine in golang. So i had to do it manually, by checking if timeout was triggered every tick. Might not be the neatest implementation, but it works and doesn't seem too bad. If you have any recommendations let me know.

Tested using manual prints to ensure that once a timeout was triggered, the simulate and simulationLoop functions would not continue.