### PR TITLE
Override HandlePropogate message function to process State... messages

### DIFF
--- a/pkg/agents/team5/messages.go
+++ b/pkg/agents/team5/messages.go
@@ -49,6 +49,20 @@ func (a *CustomAgent5) dailyMessages() {
 	a.messagingCounter++
 }
 
+//Override baseAgent's HandlePropogate, and process any StateMessages
+
+func (a *CustomAgent5) HandlePropogate(msg messages.Message) {
+	if stateFoodTakenMsg, ok := msg.(*messages.StateFoodTakenMessage); ok {
+		a.HandleStateFoodTaken(*stateFoodTakenMsg)
+	} else if stateHPMsg, ok := msg.(*messages.StateHPMessage); ok {
+		a.HandleStateHP(*stateHPMsg)
+	} else if stateIntendedFoodIntakeMsg, ok := msg.(*messages.StateIntendedFoodIntakeMessage); ok {
+		a.HandleStateIntendedFoodTaken(*stateIntendedFoodIntakeMsg)
+	}
+
+	a.SendMessage(msg)
+}
+
 //The message handler functions below are for a fully honest agent
 
 func (a *CustomAgent5) HandleAskHP(msg messages.AskHPMessage) {


### PR DESCRIPTION
# Summary
Overrides the base agent's HandlePropogate message function to manually run our Handle... functions on any State... messages, resulting in our agents "remembering" information which we pass on.