### PR TITLE
Consistent config names

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
     "Team4Agents": 2,
     "Team5Agents": 2,
     "Team6Agents": 2,
-    "Team7Agent1": 2,
+    "Team7Agents": 2,
     "RandomAgents": 2,
     "AgentHP": 100,
     "AgentsPerFloor": 1,

--- a/pkg/config/configparameters.go
+++ b/pkg/config/configparameters.go
@@ -17,14 +17,14 @@ type ConfigParameters struct {
 	FoodOnPlatform       food.FoodType           `json:"FoodOnPlatform"`
 	FoodPerAgentRatio    int                     `json:"FoodPerAgentRatio"`
 	UseFoodPerAgentRatio bool                    `json:"UseFoodPerAgentRatio"`
-	Team1AgtOne          int                     `json:"Team1AgtOne"`
-	Team1AgtTwo          int                     `json:"Team1AgtTwo"`
+	Team1Agents          int                     `json:"Team1Agents"`
+	Team1Agents2         int                     `json:"Team1Agents2"`
 	Team2Agents          int                     `json:"Team2Agents"`
 	Team3Agents          int                     `json:"Team3Agents"`
 	Team4Agents          int                     `json:"Team4Agents"`
 	Team5Agents          int                     `json:"Team5Agents"`
 	Team6Agents          int                     `json:"Team6Agents"`
-	Team7Agent1          int                     `json:"Team7Agent1"`
+	Team7Agents          int                     `json:"Team7Agents"`
 	RandomAgents         int                     `json:"RandomAgents"`
 	AgentHP              int                     `json:"AgentHP"`
 	AgentsPerFloor       int                     `json:"AgentsPerFloor"`
@@ -108,14 +108,14 @@ func CalculateDependentParameters(parameters *ConfigParameters) error {
 
 	//appending the sizes of the agents to the array
 	parameters.NumOfAgents = map[agent.AgentType]int{
-		agent.Team1Agent1: parameters.Team1AgtOne,
-		agent.Team1Agent2: parameters.Team1AgtTwo,
+		agent.Team1Agent1: parameters.Team1Agents,
+		agent.Team1Agent2: parameters.Team1Agents2,
 		agent.Team2:       parameters.Team2Agents,
 		agent.Team3:       parameters.Team3Agents,
 		agent.Team4:       parameters.Team4Agents,
 		agent.Team5:       parameters.Team5Agents,
 		agent.Team6:       parameters.Team6Agents,
-		agent.Team7:       parameters.Team7Agent1,
+		agent.Team7:       parameters.Team7Agents,
 		agent.RandomAgent: parameters.RandomAgents,
 	}
 


### PR DESCRIPTION
# Summary

We had things like `Team1AgtOne` and `Team7Agents` which was a headache to keep track of in the frontend. Renamed everything to `TeamXAgents` in the config. Agent 2 of Team 1 is named `Team1Agents2` and can still be passed by the config (but not the frontend since it really doesn't do anything).

## Testing

Prior to the fix, when you create a simulation via frontend, you would team1 and team7 agents set to 0 (name mismatch). Now everything is set correctly and `Team1Agents2` is set to 0 if frontend is creating the simulation