### PR TITLE
Simulation now creates and updates a status.json file

### DIFF
--- a/pkg/utils/logging/simstatus.go
+++ b/pkg/utils/logging/simstatus.go
@@ -1,0 +1,30 @@
+package logging
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+)
+
+type SimStatus struct {
+	Status string `json:"status"`
+}
+
+func UpdateSimStatusJson(folderPath string, status string) error {
+
+	statusStruct := SimStatus{
+		Status: status,
+	}
+
+	statusJson, err := json.Marshal(statusStruct)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(folderPath, "status.json"), statusJson, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is related to backend part of issue #212

This feature will allow frontend to easily tell the status of any simulation, and see if it still running, if it finished successfully, or if it timed out

During each run, inside the log folder there is now a status.json file created. When simulation starts, it contains the following: 

`{"status":"running"}`

If the simulation finished successfully, it gets updated to the following: 

`{"status":"finished successfully"}`

If the simulation times out it gets updated to the following: 

`{"status":"timed out"}`

The actual strings used can be modified if anyone has any suggestions. 
