### PR TITLE
Replace NPM install with ci

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd frontend && npm install && cd ..
+          cd frontend && npm ci && cd ..
 
       - name: Lint
         run: |


### PR DESCRIPTION
# Summary

Replace npm install with ci to ensure same dependency tree every build