### PR TITLE
Round() before int casting

### DIFF
--- a/pkg/infra/baseAgent.go
+++ b/pkg/infra/baseAgent.go
@@ -153,7 +153,7 @@ func (a *Base) setHP(newHP int) {
 
 // Modeled as a first order system step answer (see documentation for more information)
 func (a *Base) updateHP(foodTaken food.FoodType) {
-	hpChange := int(a.tower.healthInfo.Width * (1 - math.Pow(math.E, -float64(foodTaken)/a.tower.healthInfo.Tau)))
+	hpChange := int(math.Round(a.tower.healthInfo.Width * (1 - math.Pow(math.E, -float64(foodTaken)/a.tower.healthInfo.Tau))))
 	if a.hp >= a.tower.healthInfo.WeakLevel {
 		a.hp = a.hp + hpChange
 	} else {
@@ -164,7 +164,7 @@ func (a *Base) updateHP(foodTaken food.FoodType) {
 func (a *Base) hpDecay(healthInfo *health.HealthInfo) {
 	newHP := 0
 	if a.hp >= healthInfo.WeakLevel {
-		newHP = utilFunctions.MinInt(healthInfo.MaxHP, a.hp-(healthInfo.HPLossBase+int(float64(a.hp-healthInfo.WeakLevel)*healthInfo.HPLossSlope)))
+		newHP = utilFunctions.MinInt(healthInfo.MaxHP, a.hp-(healthInfo.HPLossBase+int(math.Round(float64(a.hp-healthInfo.WeakLevel)*healthInfo.HPLossSlope))))
 	} else {
 		if a.hp >= healthInfo.HPCritical+healthInfo.HPReqCToW {
 			newHP = healthInfo.WeakLevel

--- a/pkg/utils/globalTypes/health/health.go
+++ b/pkg/utils/globalTypes/health/health.go
@@ -52,7 +52,7 @@ func FoodRequired(currentHP int, goalHP int, healthInfo *HealthInfo) food.FoodTy
 	base := healthInfo.HPLossBase
 	numer := float64(goalHP) - (1-slope)*float64(currentHP) + float64(base) - slope*float64(healthInfo.WeakLevel)
 	denom := healthInfo.Width * (1 - slope)
-	food := food.FoodType(-1 * healthInfo.Tau * math.Log(1-numer/denom))
+	food := food.FoodType(math.Round(-1 * healthInfo.Tau * math.Log(1-numer/denom)))
 	if food < 0 {
 		if goalHP < currentHP {
 			return 0

--- a/pkg/utils/globalTypes/health/health_test.go
+++ b/pkg/utils/globalTypes/health/health_test.go
@@ -35,7 +35,7 @@ func TestFoodRequired(t *testing.T) {
 				currentHP: 100,
 				goalHP:    100,
 			},
-			want: 15,
+			want: 14,
 		},
 		{
 			name: "90 to 100",

--- a/pkg/utils/globalTypes/health/health_test.go
+++ b/pkg/utils/globalTypes/health/health_test.go
@@ -35,7 +35,7 @@ func TestFoodRequired(t *testing.T) {
 				currentHP: 100,
 				goalHP:    100,
 			},
-			want: 13,
+			want: 15,
 		},
 		{
 			name: "90 to 100",
@@ -43,7 +43,7 @@ func TestFoodRequired(t *testing.T) {
 				currentHP: 90,
 				goalHP:    100,
 			},
-			want: 24,
+			want: 25,
 		},
 		{
 			name: "100 to 90",


### PR DESCRIPTION
# Summary

<!--
*Pssst...you... yes you! Did you run `make lint` and perhaps `make format`? If not, go away, run those commands, and then come back (if you are using VS Code... then you shouldn't need to do `make lint`*
-->

<!--
MAKE SURE YOU HAVE WRITTEN UNIT TESTS FOR YOUR CODE!!!
-->

<!--
Please provide a summary of the change. What does this PR do? What does it solve?
-->

Perform math.Round() before to cast floats to integers in the health functions (updateHP, HPDecay, FoodRequired). This operation allows for better performance of the FoodRequired function

## Additional Information

<!--
Auxiliary information and additional context for the change goes here.
-->
The precision gained by this method was analysed by using the best set of health parameters we have so far, in a matlab script:
tau=15;
w=48;
b=5;
s=0.2;
WeakLevel=10;
HPCritical=3;
HPReqCToW=5;

## Test Plan

<!--
Add information on how you tested your changes.
-->