### PR TITLE
[TEAM6] Trust

### DIFF
--- a/pkg/agents/team6/config.go
+++ b/pkg/agents/team6/config.go
@@ -125,7 +125,7 @@ func New(baseAgent *infra.Base) (infra.Agent, error) {
 		platOnFloorCtr:      0,
 		prevFloor:           -1,
 		trustTeams:          make(trust),
-		neighbours:          neighbours{},
+		neighbours:          neighbours{above: uuid.Nil, below: uuid.Nil},
 	}, nil
 }
 

--- a/pkg/agents/team6/config.go
+++ b/pkg/agents/team6/config.go
@@ -7,12 +7,15 @@ import (
 
 	"github.com/SOMAS2021/SOMAS2021/pkg/infra"
 	"github.com/SOMAS2021/SOMAS2021/pkg/messages"
+	"github.com/google/uuid"
 
 	//"github.com/SOMAS2021/SOMAS2021/pkg/messages"
 	"github.com/SOMAS2021/SOMAS2021/pkg/utils/globalTypes/food"
 )
 
 type memory []food.FoodType
+
+type trust map[uuid.UUID]int
 
 type behaviour float64
 
@@ -22,6 +25,10 @@ type behaviour float64
 //  selfish
 //  narcissist
 // )
+type neighbours struct {
+	above uuid.UUID
+	below uuid.UUID
+}
 
 type utilityParameters struct {
 	// Greediness
@@ -70,6 +77,10 @@ type CustomAgent6 struct {
 	platOnFloorCtr int
 	// Keeps track of previous floor to see if agent has been reassigned
 	prevFloor int
+	// Mapping of agent id to trust
+	trustTeams trust
+	// IDs of agents above and below (based on what we've been told)
+	neighbours neighbours
 }
 
 type thresholdBehaviourPair struct {
@@ -107,12 +118,14 @@ func New(baseAgent *infra.Base) (infra.Agent, error) {
 		reqLeaveFoodAmount:  -1,
 		lastFoodTaken:       0,
 		averageFoodIntake:   0.0,
-		longTermMemory:      memory{},
-		shortTermMemory:     memory{},
+		longTermMemory:      make(memory, 0), //memory{},
+		shortTermMemory:     make(memory, 0), //memory{},
 		numReassigned:       0,
 		reassignPeriodGuess: 0,
 		platOnFloorCtr:      0,
 		prevFloor:           -1,
+		trustTeams:          make(trust),
+		neighbours:          neighbours{},
 	}, nil
 }
 


### PR DESCRIPTION
# Summary

Added variables for trust and means of keeping track of neighbours. Will continue with implementing trust in parallel with messages in future

## Additional Information

Changed initialisation of array in config:

`memory{}` looks like an empty struct of type memory. `make(memory, 0)` clarifies that it's a slice (and calls `runtime.makeslice`)

neighbours struct stores the conceived IDs of the above and below neighbours for use in the trust map