### PR TITLE
[Team 5] Update satisfaction calculation

### DIFF
--- a/pkg/agents/team5/agent.go
+++ b/pkg/agents/team5/agent.go
@@ -34,7 +34,7 @@ type CustomAgent5 struct {
 	currentProposal   *messages.Treaty
 	attemptToEat      bool
 	leadership        int
-	lastFood          int
+	lastFood          food.FoodType
 	// Social network of other agents
 	socialMemory      map[uuid.UUID]Memory
 	surroundingAgents map[int]uuid.UUID
@@ -74,7 +74,7 @@ func (a *CustomAgent5) updateSelfishness() {
 }
 
 func (a *CustomAgent5) updateSatisfaction() {
-	tmp := int(a.CurrPlatFood())
+	tmp := a.CurrPlatFood()
 	if a.lastFood*120.0/100.0 <= tmp {
 		a.satisfaction += 2
 	} else if a.lastFood*110.0/100.0 <= tmp {
@@ -156,7 +156,7 @@ func (a *CustomAgent5) Run() {
 		if a.Floor() == a.rememberFloor { // if the agent is still on the same floor it can update its satisfaction
 			a.updateSatisfaction()
 		}
-		a.lastFood = int(a.CurrPlatFood())
+		a.lastFood = a.CurrPlatFood()
 		lastMeal, err := a.TakeFood(a.attemptFood)
 		if err != nil {
 			switch err.(type) {

--- a/pkg/agents/team5/agent.go
+++ b/pkg/agents/team5/agent.go
@@ -34,6 +34,7 @@ type CustomAgent5 struct {
 	currentProposal   *messages.Treaty
 	attemptToEat      bool
 	leadership        int
+	lastFood          int
 	// Social network of other agents
 	socialMemory      map[uuid.UUID]Memory
 	surroundingAgents map[int]uuid.UUID
@@ -48,13 +49,14 @@ func New(baseAgent *infra.Base) (infra.Agent, error) {
 		hpAfterEating:     baseAgent.HealthInfo().MaxHP, // Stores HP value after eating in a day
 		currentAimHP:      baseAgent.HealthInfo().MaxHP, // Stores aim HP for a given day
 		attemptFood:       0,                            // Stores food agent will attempt to eat in a
-		satisfaction:      0,                            // Scale of -3 to 3, with 3 being satisfied and unsatisfied
+		satisfaction:      -10,                          // Scale of -50 to 50
 		rememberAge:       -1,                           // To check if a day has passed by our age increasing
 		rememberFloor:     0,                            // Store the floor we are on so we can see if we have been reshuffled
 		messagingCounter:  0,                            // Counter so that various messages are sent throughout the day
 		treatySendCounter: 0,                            // Counter so that treaty messages can be sent
 		attemptToEat:      true,                         // To check if we have already attempted to eat in a day. Needed because HasEaten() does not update if there is no food on the platform
 		leadership:        rand.Intn(10),                // Initialise a random leadership value for each agent, used to determine whether they try to cause change in the tower. 0 is more likely to become a leader
+		lastFood:          0,                            // How much food arrived at the platform on the previous day assuming that the agent is still on the same floor
 		socialMemory:      make(map[uuid.UUID]Memory),   // Memory of other agents, key is agent id
 		surroundingAgents: make(map[int]uuid.UUID),      // Map agent IDs of surrounding floors relative to current floor
 	}, nil
@@ -72,17 +74,23 @@ func (a *CustomAgent5) updateSelfishness() {
 }
 
 func (a *CustomAgent5) updateSatisfaction() {
-	if PercentageHP(a) >= 100 {
-		a.satisfaction = 3
+	tmp := int(a.CurrPlatFood())
+	if a.lastFood*120.0/100.0 <= tmp {
+		a.satisfaction += 2
+	} else if a.lastFood*110.0/100.0 <= tmp {
+		a.satisfaction += 1
+	} else if a.lastFood*70.0/100.0 >= tmp {
+		a.satisfaction -= 2
+	} else if a.lastFood*80.0/100.0 >= tmp {
+		a.satisfaction -= 1
 	}
-	if a.lastMeal == 0 && a.satisfaction > -3 {
-		a.satisfaction--
+
+	if a.satisfaction > 50 {
+		a.satisfaction = 50
 	}
-	if PercentageHP(a) < 25 && a.satisfaction > -3 {
-		a.satisfaction--
-	}
-	if PercentageHP(a) > 75 && a.satisfaction < 3 {
-		a.satisfaction++
+
+	if a.satisfaction < -50 {
+		a.satisfaction = -50
 	}
 }
 
@@ -145,6 +153,10 @@ func (a *CustomAgent5) Run() {
 	// When platform reaches our floor and we haven't tried to eat, then try to eat
 	if a.CurrPlatFood() != -1 && a.attemptToEat {
 		a.treatyOverride()
+		if a.Floor() == a.rememberFloor { // if the agent is still on the same floor it can update its satisfaction
+			a.updateSatisfaction()
+		}
+		a.lastFood = int(a.CurrPlatFood())
 		lastMeal, err := a.TakeFood(a.attemptFood)
 		if err != nil {
 			switch err.(type) {
@@ -157,12 +169,12 @@ func (a *CustomAgent5) Run() {
 				log.Error("Simulation - team5/agent.go: \t Impossible error reached")
 			}
 		}
+
 		a.lastMeal = lastMeal
 		if a.lastMeal > 0 {
 			a.daysSinceLastMeal = 0
 		}
 		a.hpAfterEating = a.HP()
-		a.updateSatisfaction()
 		a.attemptToEat = false
 	}
 }

--- a/pkg/agents/team5/social.go
+++ b/pkg/agents/team5/social.go
@@ -49,7 +49,7 @@ func (a *CustomAgent5) addToSocialFavour(id uuid.UUID, change int) {
 		a.newMemory(id)
 	}
 	mem := a.socialMemory[id]
-	mem.favour = a.restrictToRange(0, 10, mem.favour+change)
+	mem.favour = restrictToRange(0, 10, mem.favour+change)
 	a.socialMemory[id] = mem
 }
 

--- a/pkg/agents/team5/utils.go
+++ b/pkg/agents/team5/utils.go
@@ -10,11 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func PercentageHP(a *CustomAgent5) int {
-	return int(float64(a.HP()) / float64(a.HealthInfo().MaxHP) * 100.0)
-}
-
-func (a *CustomAgent5) restrictToRange(lowerBound, upperBound, num int) int {
+func restrictToRange(lowerBound, upperBound, num int) int {
 	if num < lowerBound {
 		return lowerBound
 	}


### PR DESCRIPTION
* add comments from standup

* Messaging Expansion

- Messages sent to +- 2 floors
- Messaging counter reset so that messages are sent throughout the day
- Fix issue of daysSinceLastSeen not incrementing
- Removed intented food from judgement

* override HandlePropogate message function to process State... messages before passing message on (#224)

* Added attemptToEatParameter

-HasEaten() does not update if the platform has 0 food. So we do our own check for if we have already tries to eat in a day

* Added Leadership and checkForLeader()

* new satisfaction

* removed typo (8 instead of 80) & update at the end

Co-authored-by: Jason Zheng <jzz18@ic.ac.uk>
Co-authored-by: Rhys-J <rhysjohnson16@gmail.com>
Co-authored-by: Ben Stobbs <ben@stobbs.com>

# Summary

<!--
*Pssst...you... yes you! Did you run `make lint` and perhaps `make format`? If not, go away, run those commands, and then come back (if you are using VS Code... then you shouldn't need to do `make lint`*
-->

<!--
MAKE SURE YOU HAVE WRITTEN UNIT TESTS FOR YOUR CODE!!!
-->

<!--
Please provide a summary of the change. What does this PR do? What does it solve?
-->

## Additional Information

<!--
Auxiliary information and additional context for the change goes here.
-->

## Test Plan

<!--
Add information on how you tested your changes.
-->