### PR TITLE
Add messages logging for message type counts and treaty accept/reject stats

### DIFF
--- a/frontend/src/Components/Results/Graphs/MultiBarChart.tsx
+++ b/frontend/src/Components/Results/Graphs/MultiBarChart.tsx
@@ -1,4 +1,3 @@
-import { Colors } from "@blueprintjs/core";
 import {
   Chart as ChartJS,
   CategoryScale,

--- a/frontend/src/Components/Results/Graphs/MultiBarChart.tsx
+++ b/frontend/src/Components/Results/Graphs/MultiBarChart.tsx
@@ -17,10 +17,7 @@ interface MultiBarChartProps {
   xAxis: any[];
   data: any[];
 }
-// Y axis number of messages
-// X axis agent type
-// let data contain the values (y-axis) and titles (message type)
-// i.e. [{label1: [], data1: []}, ...]
+
 export default function MultiBarChart(props: MultiBarChartProps) {
   const { xAxis, data } = props;
   return (

--- a/frontend/src/Components/Results/Graphs/MultiBarChart.tsx
+++ b/frontend/src/Components/Results/Graphs/MultiBarChart.tsx
@@ -1,0 +1,35 @@
+import { Colors } from "@blueprintjs/core";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Bar } from "react-chartjs-2";
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, Title, Tooltip, Legend);
+
+interface MultiBarChartProps {
+  xAxis: any[];
+  data: any[];
+}
+// Y axis number of messages
+// X axis agent type
+// let data contain the values (y-axis) and titles (message type)
+// i.e. [{label1: [], data1: []}, ...]
+export default function MultiBarChart(props: MultiBarChartProps) {
+  const { xAxis, data } = props;
+  return (
+    <Bar
+      data={{
+        labels: xAxis,
+        datasets: data,
+      }}
+    />
+  );
+}

--- a/frontend/src/Components/Results/Graphs/PieChart.tsx
+++ b/frontend/src/Components/Results/Graphs/PieChart.tsx
@@ -1,4 +1,4 @@
-import { Colors } from "@blueprintjs/core";
+// import { Colors } from "@blueprintjs/core";
 import {
   Chart as ChartJS,
   CategoryScale,

--- a/frontend/src/Components/Results/Graphs/PieChart.tsx
+++ b/frontend/src/Components/Results/Graphs/PieChart.tsx
@@ -1,0 +1,33 @@
+import { Colors } from "@blueprintjs/core";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+  ArcElement,
+} from "chart.js";
+import { Pie } from "react-chartjs-2";
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, ArcElement, Title, Tooltip, Legend);
+
+interface PieChartProps {
+  labels: any[];
+  data: any[];
+}
+
+export default function PieChart(props: PieChartProps) {
+  const { labels, data } = props;
+
+  return (
+    <Pie
+      data={{
+        labels: labels,
+        datasets: data,
+      }}
+    />
+  );
+}

--- a/frontend/src/Components/Results/Stats.tsx
+++ b/frontend/src/Components/Results/Stats.tsx
@@ -7,9 +7,12 @@ import {
   UtilityOnDeath,
   AverageUtilityPerAgent,
   AverageAgeUponDeath,
+  ParseMessageStats,
+  ParseTreatyAcceptanceStats,
 } from "../../Helpers/Utils";
 import { Result } from "../../Helpers/Result";
 import BarChart from "./Graphs/BarChart";
+import MultiBarChart from "./Graphs/MultiBarChart";
 import LineChart from "./Graphs/LineChart";
 
 interface StatsViewerProps {
@@ -22,6 +25,8 @@ export default function StatsViewer(props: StatsViewerProps) {
   let utilityPerAgent = AverageUtilityPerAgent(result.utility);
   let utilityUponDeath = UtilityOnDeath(result.utility);
   let averageAgeUponDeath = AverageAgeUponDeath(result.deaths);
+  let messageStats = ParseMessageStats(result.messages);
+  let treatyAcceptanceStats = ParseTreatyAcceptanceStats(result.messages);
   return (
     <div className="row">
       <div className="col-lg-6">
@@ -87,6 +92,12 @@ export default function StatsViewer(props: StatsViewerProps) {
             xAxis={Object.keys(averageAgeUponDeath)}
             graphTitle="Average age upon death per Agent type"
           />
+        </div>
+        <div className="col-lg-6">
+          <MultiBarChart xAxis={result.messages.atypes} data={treatyAcceptanceStats} />
+        </div>
+        <div className="row">
+          <MultiBarChart xAxis={result.messages.atypes} data={messageStats} />
         </div>
       </div>
     </div>

--- a/frontend/src/Helpers/Logging/Message.ts
+++ b/frontend/src/Helpers/Logging/Message.ts
@@ -1,0 +1,19 @@
+import { GetFile } from "../API";
+import { Log } from "./Log";
+
+export interface MessagesLog extends Log {
+  atypes: string[];
+  msgcount: number[][];
+  mtypes: string[];
+  treatyResponses: number[][];
+}
+
+export function GetMessagesLog(filename: string): Promise<MessagesLog> {
+  return new Promise<MessagesLog>((resolve, reject) => {
+    GetFile(filename, "messages")
+      .then((u) => {
+        resolve(u[0] as MessagesLog);
+      })
+      .catch((err) => reject(err));
+  });
+}

--- a/frontend/src/Helpers/Result.ts
+++ b/frontend/src/Helpers/Result.ts
@@ -4,6 +4,7 @@ import { DeathLog, GetDeathLogs } from "./Logging/Death";
 import { FoodLog, GetFoodLogs } from "./Logging/Food";
 import { GetSimConfig, SimConfig } from "./SimConfig";
 import { GetUtilityLogs } from "./Logging/Utility";
+import { GetMessagesLog, MessagesLog } from "./Logging/Message";
 
 export enum SimStatusExec {
   "finished",
@@ -23,6 +24,7 @@ export interface Result {
   config: SimConfig;
   simStatus: SimStatus;
   utility: UtilityLog[];
+  messages: MessagesLog;
 }
 
 function GetSimStatus(filename: string): Promise<SimStatus> {
@@ -71,13 +73,17 @@ export function GetResult(filename: string): Promise<Result> {
     // status
     var status: SimStatus = {
       status: SimStatusExec.finished,
-      maxTick: 3000
+      maxTick: 3000,
     };
     promises.push(GetSimStatus(filename).then((s) => (status = s)));
 
     // Agent state
     var utility: UtilityLog[] = [];
     promises.push(GetUtilityLogs(filename).then((a) => (utility = a)));
+
+    // Messages aggregate stats
+    var messages: MessagesLog;
+    promises.push(GetMessagesLog(filename).then((m) => (messages = m)));
 
     // all
     Promise.all(promises).then((_) =>
@@ -88,6 +94,7 @@ export function GetResult(filename: string): Promise<Result> {
         config: config,
         simStatus: status,
         utility: utility,
+        messages: messages,
       })
     );
   });

--- a/frontend/src/Helpers/Utils.ts
+++ b/frontend/src/Helpers/Utils.ts
@@ -1,5 +1,26 @@
+import { Colors } from "@blueprintjs/core";
 import { DeathLog } from "./Logging/Death";
+import { MessagesLog } from "./Logging/Message";
 import { UtilityLog } from "./Logging/Utility";
+
+const arbitraryStackKey = "stack1";
+const colorFamily = [
+  "#0074D9",
+  "#FF4136",
+  "#2ECC40",
+  "#FF851B",
+  "#7FDBFF",
+  "#B10DC9",
+  "#FFDC00",
+  "#001f3f",
+  "#39CCCC",
+  "#01FF70",
+  "#85144b",
+  "#F012BE",
+  "#3D9970",
+  "#111111",
+  "#AAAAAA",
+];
 
 export function Average(arr: number[]): number {
   return arr.length > 0 ? arr.reduce((a, b) => a + b) / arr.length : 0;
@@ -63,4 +84,37 @@ export function AverageAgeUponDeath(deathLogs: DeathLog[]): { [agentType: string
     }
   }
   return ageMap;
+}
+
+// This needs to return an array of chartable objects
+export function ParseMessageStats(stats: MessagesLog): any[] {
+  var processedStats: any[] = [];
+  var mtypes = stats.mtypes;
+  var msgcount = stats.msgcount;
+
+  // for each agent type
+  for (let i = 0; i < mtypes.length; i++) {
+    processedStats.push({
+      label: mtypes[i], // Graph title
+      data: msgcount[i], // Data (y-axis)
+      backgroundColor: colorFamily[i],
+      stack: arbitraryStackKey,
+    });
+  }
+
+  return processedStats;
+}
+export function ParseTreatyAcceptanceStats(stats: MessagesLog): any[] {
+  return [
+    {
+      label: "Treaties Rejected", // Graph title
+      data: stats.treatyResponses[0], // Data (y-axis)
+      backgroundColor: Colors.RED3,
+    },
+    {
+      label: "Treaties Accepted", // Graph title
+      data: stats.treatyResponses[1], // Data (y-axis)
+      backgroundColor: Colors.GREEN3,
+    },
+  ];
 }

--- a/frontend/src/Helpers/Utils.ts
+++ b/frontend/src/Helpers/Utils.ts
@@ -114,7 +114,7 @@ export function ParseTreatyAcceptanceStats(stats: MessagesLog): any[] {
     {
       label: "Treaties Accepted", // Graph title
       data: stats.treatyResponses[1], // Data (y-axis)
-      backgroundColor: Colors.GREEN3,
+      backgroundColor: Colors.GREEN1,
     },
   ];
 }

--- a/frontend/src/Helpers/Utils.ts
+++ b/frontend/src/Helpers/Utils.ts
@@ -109,7 +109,7 @@ export function ParseTreatyAcceptanceStats(stats: MessagesLog): any[] {
     {
       label: "Treaties Rejected", // Graph title
       data: stats.treatyResponses[0], // Data (y-axis)
-      backgroundColor: Colors.RED3,
+      backgroundColor: Colors.RED1,
     },
     {
       label: "Treaties Accepted", // Graph title

--- a/frontend/src/Helpers/Utils.ts
+++ b/frontend/src/Helpers/Utils.ts
@@ -5,21 +5,21 @@ import { UtilityLog } from "./Logging/Utility";
 
 const arbitraryStackKey = "stack1";
 const colorFamily = [
-  "#0074D9",
-  "#FF4136",
-  "#2ECC40",
-  "#FF851B",
-  "#7FDBFF",
-  "#B10DC9",
-  "#FFDC00",
-  "#001f3f",
-  "#39CCCC",
-  "#01FF70",
-  "#85144b",
-  "#F012BE",
-  "#3D9970",
-  "#111111",
-  "#AAAAAA",
+  "#1F4B99",
+  "#2F649C",
+  "#447C9F",
+  "#5D94A1",
+  "#7CAAA2",
+  "#A0BFA2",
+  "#CCD3A1",
+  "#FFE39F",
+  "#F6C880",
+  "#EBAE65",
+  "#DE944D",
+  "#D07A38",
+  "#C06126",
+  "#B04718",
+  "#9E2B0E",
 ];
 
 export function Average(arr: number[]): number {

--- a/pkg/infra/baseAgentMessages.go
+++ b/pkg/infra/baseAgentMessages.go
@@ -17,6 +17,7 @@ func (a *Base) ReceiveMessage() messages.Message {
 func (a *Base) SendMessage(msg messages.Message) {
 	a.tower.SendMessage(a.floor, msg)
 	a.tower.stateLog.LogStoryAgentSentMessage(a.tower.dayInfo, a.storyState(), msg)
+	a.tower.stateLog.LogMessage(a.tower.dayInfo, a.storyState(), msg)
 }
 
 func (a *Base) ActiveTreaties() map[uuid.UUID]messages.Treaty {

--- a/pkg/messages/proposeTreatyMessage.go
+++ b/pkg/messages/proposeTreatyMessage.go
@@ -38,5 +38,5 @@ func (msg *ProposeTreatyMessage) Visit(a Agent) {
 
 // TODO: complete treaty details
 func (msg *ProposeTreatyMessage) StoryLog() string {
-	return "Treaty details"
+	return "Condition: " + msg.treaty.Condition().String() + " Req: " + msg.treaty.Request().String()
 }

--- a/pkg/simulation/simulation.go
+++ b/pkg/simulation/simulation.go
@@ -103,6 +103,9 @@ func (sE *SimEnv) Simulate(ctx context.Context, ch chan<- string) {
 			agent.CustomLogs()
 		}
 	}
+
+	// dispatch loggers
+	sE.stateLog.SimEnd(sE.dayInfo)
 }
 
 func (s *SimEnv) Log(message string, fields ...Fields) {


### PR DESCRIPTION
See title. Chart with all message types is a bit doomed, not really sure what better other way to display it. For convenience I've added a MultiBarChart and PieChart to our graph arsenal, but when testing our the visualizations much preferred the stacked bars option so I left it at that (though feel free to amend)

Treaties accept/reject
![image](https://user-images.githubusercontent.com/5508348/148872072-78211e62-3e06-4a06-a9b5-d9cbd1c70909.png)

Message types per agent
![image](https://user-images.githubusercontent.com/5508348/148872121-42e2bf06-c6ff-4e5f-8328-f3a68a172705.png)

